### PR TITLE
feat: Implémentation de la gestion de la galerie d'images

### DIFF
--- a/pifpaf/database/seeders/VerificationSeeder.php
+++ b/pifpaf/database/seeders/VerificationSeeder.php
@@ -4,6 +4,8 @@ namespace Database\Seeders;
 
 use Illuminate\Database\Seeder;
 use App\Models\User;
+use App\Models\Item;
+use App\Models\ItemImage;
 
 class VerificationSeeder extends Seeder
 {
@@ -14,10 +16,24 @@ class VerificationSeeder extends Seeder
      */
     public function run()
     {
-        User::create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
-            'password' => bcrypt('password'),
+        // Créer un utilisateur spécifique pour le test
+        $user = User::factory()->create([
+            'email' => 'seller@example.com',
         ]);
+
+        // Créer une annonce avec 3 images pour cet utilisateur
+        Item::factory()
+            ->for($user)
+            ->has(
+                ItemImage::factory()
+                    ->count(3)
+                    ->sequence(
+                        ['is_primary' => true, 'order' => 0],
+                        ['is_primary' => false, 'order' => 1],
+                        ['is_primary' => false, 'order' => 2]
+                    ),
+                'images' // Spécifier le nom de la relation ici
+            )
+            ->create();
     }
 }

--- a/pifpaf/routes/web.php
+++ b/pifpaf/routes/web.php
@@ -56,6 +56,8 @@ Route::middleware('auth')->group(function () {
 
     // Route pour la suppression d'image
     Route::delete('/item-images/{itemImage}', [ItemImageController::class, 'destroy'])->name('item-images.destroy');
+    Route::post('/item-images/{itemImage}/set-primary', [ItemImageController::class, 'setPrimary'])->name('item-images.set-primary');
+    Route::post('/item-images/reorder', [ItemImageController::class, 'reorder'])->name('item-images.reorder');
 });
 
 Route::get('/items/{item}', [ItemController::class, 'show'])->name('items.show');


### PR DESCRIPTION
Ajoute les fonctionnalités suivantes à la page d'édition d'une annonce :
- Définir une image comme principale (US-ANN-2).
- Réorganiser les images par glisser-déposer (US-ANN-3).

Crée les routes et les méthodes de contrôleur nécessaires pour gérer ces actions. Met à jour la vue d'édition avec une interface utilisateur intuitive pour ces nouvelles fonctionnalités, y compris la mise en évidence de l'image principale et l'intégration de SortableJS. Ajoute un seeder de vérification pour faciliter les tests du frontend.