### PR TITLE
fix(navigation): Ajout du lien messagerie sur mobile

### DIFF
--- a/doc/todo.md
+++ b/doc/todo.md
@@ -62,8 +62,8 @@
 - [ ] **US-COM-5:** Créer le formulaire d'ouverture de litige.
 
 ### Ligne de Développement: Jules 2 (Communication)
-- [ ] **US-COM-3:** Permettre de démarrer une conversation.
-- [ ] **US-COM-4:** Créer l'interface de messagerie (boîte de réception).
+- [x] **US-COM-3:** Permettre de démarrer une conversation.
+- [x] **US-COM-4:** Créer l'interface de messagerie (boîte de réception).
 
 ### Ligne de Développement: Jules 3 (IA v2)
 - [x] **US-IA-5:** Développer la capacité de l'IA à traiter plusieurs objets sur une photo.

--- a/pifpaf/app/Http/Controllers/ConversationController.php
+++ b/pifpaf/app/Http/Controllers/ConversationController.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Conversation;
+use App\Models\Item;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class ConversationController extends Controller
+{
+    use AuthorizesRequests;
+
+    /**
+     * Affiche la liste des conversations de l'utilisateur.
+     */
+    public function index()
+    {
+        $user = Auth::user();
+
+        $conversations = Conversation::where('buyer_id', $user->id)
+            ->orWhere('seller_id', $user->id)
+            ->with(['item.primaryImage', 'latestMessage', 'buyer', 'seller'])
+            ->get()
+            // Trier pour que les conversations avec le message le plus récent apparaissent en premier
+            ->sortByDesc(function ($conversation) {
+                return $conversation->latestMessage ? $conversation->latestMessage->created_at : $conversation->updated_at;
+            });
+
+
+        return view('conversations.index', compact('conversations'));
+    }
+
+    /**
+     * Affiche une conversation spécifique.
+     */
+    public function show(Conversation $conversation)
+    {
+        $this->authorize('view', $conversation);
+
+        // Marquer les messages comme lus pour l'utilisateur actuel
+        $conversation->messages()
+            ->where('user_id', '!=', Auth::id())
+            ->whereNull('read_at')
+            ->update(['read_at' => now()]);
+
+        return view('conversations.show', compact('conversation'));
+    }
+
+    /**
+     * Crée une nouvelle conversation ou redirige vers une conversation existante.
+     */
+    public function store(Request $request)
+    {
+        $request->validate([
+            'item_id' => 'required|exists:items,id',
+        ]);
+
+        $item = Item::findOrFail($request->item_id);
+
+        // L'utilisateur ne peut pas démarrer une conversation avec lui-même
+        if ($item->user_id == Auth::id()) {
+            return back()->with('error', 'Vous ne pouvez pas démarrer une conversation pour votre propre annonce.');
+        }
+
+        // Vérifier si une conversation existe déjà
+        $conversation = Conversation::where('item_id', $item->id)
+            ->where('buyer_id', Auth::id())
+            ->first();
+
+        if (!$conversation) {
+            $conversation = Conversation::create([
+                'item_id' => $item->id,
+                'buyer_id' => Auth::id(),
+                'seller_id' => $item->user_id,
+            ]);
+        }
+
+        return redirect()->route('conversations.show', $conversation);
+    }
+}

--- a/pifpaf/app/Http/Controllers/MessageController.php
+++ b/pifpaf/app/Http/Controllers/MessageController.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Conversation;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class MessageController extends Controller
+{
+    use AuthorizesRequests;
+
+    /**
+     * Enregistre un nouveau message dans une conversation.
+     */
+    public function store(Request $request, Conversation $conversation)
+    {
+        $this->authorize('update', $conversation);
+
+        $request->validate([
+            'content' => 'required|string',
+        ]);
+
+        $conversation->messages()->create([
+            'user_id' => Auth::id(),
+            'content' => $request->content,
+        ]);
+
+        return back();
+    }
+}

--- a/pifpaf/app/Models/Conversation.php
+++ b/pifpaf/app/Models/Conversation.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Conversation extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'item_id',
+        'buyer_id',
+        'seller_id',
+    ];
+
+    /**
+     * Obtenir l'article associé à la conversation.
+     */
+    public function item()
+    {
+        return $this->belongsTo(Item::class);
+    }
+
+    /**
+     * Obtenir l'utilisateur acheteur de la conversation.
+     */
+    public function buyer()
+    {
+        return $this->belongsTo(User::class, 'buyer_id');
+    }
+
+    /**
+     * Obtenir l'utilisateur vendeur de la conversation.
+     */
+    public function seller()
+    {
+        return $this->belongsTo(User::class, 'seller_id');
+    }
+
+    /**
+     * Obtenir les messages de la conversation.
+     */
+    public function messages()
+    {
+        return $this->hasMany(Message::class);
+    }
+
+    /**
+     * Obtenir le dernier message de la conversation.
+     */
+    public function latestMessage()
+    {
+        return $this->hasOne(Message::class)->latestOfMany();
+    }
+}

--- a/pifpaf/app/Models/Message.php
+++ b/pifpaf/app/Models/Message.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Message extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'conversation_id',
+        'user_id',
+        'content',
+        'read_at',
+    ];
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'read_at' => 'datetime',
+    ];
+
+    /**
+     * Obtenir la conversation à laquelle le message appartient.
+     */
+    public function conversation()
+    {
+        return $this->belongsTo(Conversation::class);
+    }
+
+    /**
+     * Obtenir l'utilisateur qui a envoyé le message.
+     */
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/pifpaf/app/Policies/ConversationPolicy.php
+++ b/pifpaf/app/Policies/ConversationPolicy.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Conversation;
+use App\Models\User;
+use Illuminate\Auth\Access\Response;
+
+class ConversationPolicy
+{
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user): bool
+    {
+        return true;
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, Conversation $conversation): bool
+    {
+        return $user->id === $conversation->buyer_id || $user->id === $conversation->seller_id;
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user): bool
+    {
+        return true;
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, Conversation $conversation): bool
+    {
+        return $user->id === $conversation->buyer_id || $user->id === $conversation->seller_id;
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, Conversation $conversation): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can restore the model.
+     */
+    public function restore(User $user, Conversation $conversation): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can permanently delete the model.
+     */
+    public function forceDelete(User $user, Conversation $conversation): bool
+    {
+        return false;
+    }
+}

--- a/pifpaf/app/Providers/AuthServiceProvider.php
+++ b/pifpaf/app/Providers/AuthServiceProvider.php
@@ -18,6 +18,7 @@ class AuthServiceProvider extends ServiceProvider
     protected $policies = [
         Item::class => ItemPolicy::class,
         PickupAddress::class => PickupAddressPolicy::class,
+        \App\Models\Conversation::class => \App\Policies\ConversationPolicy::class,
     ];
 
     /**

--- a/pifpaf/database/factories/ConversationFactory.php
+++ b/pifpaf/database/factories/ConversationFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Item;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Conversation>
+ */
+class ConversationFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'item_id' => Item::factory(),
+            'buyer_id' => User::factory(),
+            'seller_id' => User::factory(),
+        ];
+    }
+}

--- a/pifpaf/database/factories/MessageFactory.php
+++ b/pifpaf/database/factories/MessageFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Conversation;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Message>
+ */
+class MessageFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'conversation_id' => Conversation::factory(),
+            'user_id' => User::factory(),
+            'content' => $this->faker->sentence,
+            'read_at' => null,
+        ];
+    }
+}

--- a/pifpaf/database/migrations/2025_11_02_140926_create_conversations_table.php
+++ b/pifpaf/database/migrations/2025_11_02_140926_create_conversations_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('conversations', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('item_id')->constrained()->onDelete('cascade');
+            $table->foreignId('buyer_id')->constrained('users')->onDelete('cascade');
+            $table->foreignId('seller_id')->constrained('users')->onDelete('cascade');
+            $table->timestamps();
+
+            // Assurer qu'il ne peut y avoir qu'une seule conversation par acheteur pour un article donné
+            $table->unique(['item_id', 'buyer_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('conversations');
+    }
+};

--- a/pifpaf/database/migrations/2025_11_02_140927_create_messages_table.php
+++ b/pifpaf/database/migrations/2025_11_02_140927_create_messages_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('messages', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('conversation_id')->constrained()->onDelete('cascade');
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->text('content');
+            $table->timestamp('read_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('messages');
+    }
+};

--- a/pifpaf/resources/views/auth/register.blade.php
+++ b/pifpaf/resources/views/auth/register.blade.php
@@ -1,43 +1,42 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Register</title>
-</head>
-<body>
+<x-guest-layout>
+    <!-- Validation Errors -->
+    <x-auth-validation-errors class="mb-4" :errors="$errors" />
+
     <form method="POST" action="{{ route('register') }}">
         @csrf
 
         <!-- Name -->
         <div>
-            <label for="name">Name</label>
-            <input id="name" type="text" name="name" :value="old('name')" required autofocus>
+            <x-input-label for="name" :value="__('Nom')" />
+            <x-text-input id="name" class="block mt-1 w-full" type="text" name="name" :value="old('name')" required autofocus />
         </div>
 
         <!-- Email Address -->
         <div class="mt-4">
-            <label for="email">Email</label>
-            <input id="email" type="email" name="email" :value="old('email')" required>
+            <x-input-label for="email" :value="__('Adresse e-mail')" />
+            <x-text-input id="email" class="block mt-1 w-full" type="email" name="email" :value="old('email')" required />
         </div>
 
         <!-- Password -->
         <div class="mt-4">
-            <label for="password">Password</label>
-            <input id="password" type="password" name="password" required>
+            <x-input-label for="password" :value="__('Mot de passe')" />
+            <x-text-input id="password" class="block mt-1 w-full" type="password" name="password" required autocomplete="new-password" />
         </div>
 
         <!-- Confirm Password -->
         <div class="mt-4">
-            <label for="password_confirmation">Confirm Password</label>
-            <input id="password_confirmation" type="password" name="password_confirmation" required>
+            <x-input-label for="password_confirmation" :value="__('Confirmation du mot de passe')" />
+            <x-text-input id="password_confirmation" class="block mt-1 w-full" type="password" name="password_confirmation" required />
         </div>
 
-        <div>
-            <button type="submit">
-                Register
-            </button>
+        <div class="flex items-center justify-end mt-4">
+            <a class="underline text-sm text-gray-600 hover:text-gray-900" href="{{ route('login') }}">
+                {{ __('Déjà inscrit?') }}
+            </a>
+
+            <x-primary-button class="ml-4">
+                {{ __('S\'inscrire') }}
+            </x-primary-button>
         </div>
     </form>
-</body>
-</html>
+</x-guest-layout>

--- a/pifpaf/resources/views/conversations/index.blade.php
+++ b/pifpaf/resources/views/conversations/index.blade.php
@@ -1,0 +1,66 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Messagerie') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 bg-white border-b border-gray-200">
+                    <h3 class="text-2xl font-bold mb-6">Vos Conversations</h3>
+
+                    @if($conversations->isEmpty())
+                        <p>Vous n'avez aucune conversation pour le moment.</p>
+                    @else
+                        <div class="space-y-4">
+                            @foreach($conversations as $conversation)
+                                @php
+                                    // Déterminer qui est l'autre participant
+                                    $otherParticipant = $conversation->buyer_id == Auth::id() ? $conversation->seller : $conversation->buyer;
+                                @endphp
+                                <a href="{{ route('conversations.show', $conversation) }}" class="block p-4 rounded-lg shadow hover:bg-gray-100 transition duration-150 ease-in-out">
+                                    <div class="flex items-start space-x-4">
+                                        <!-- Image de l'article -->
+                                        <div class="flex-shrink-0">
+                                            @if($conversation->item && $conversation->item->primaryImage)
+                                                <img class="w-20 h-20 rounded-md object-cover" src="{{ asset('storage/' . $conversation->item->primaryImage->path) }}" alt="{{ $conversation->item->title }}">
+                                            @else
+                                                <div class="w-20 h-20 rounded-md bg-gray-200 flex items-center justify-center">
+                                                    <span class="text-xs text-gray-500">Aucune image</span>
+                                                </div>
+                                            @endif
+                                        </div>
+
+                                        <div class="flex-grow">
+                                            <!-- Titre de l'article et nom de l'interlocuteur -->
+                                            <div class="flex justify-between items-center">
+                                                <p class="font-semibold text-lg">{{ $conversation->item->title ?? 'Article supprimé' }}</p>
+                                                <p class="text-sm text-gray-600">
+                                                    Conversation avec <span class="font-medium">{{ $otherParticipant->name }}</span>
+                                                </p>
+                                            </div>
+
+                                            <!-- Dernier message -->
+                                            <div class="mt-2 text-sm text-gray-700">
+                                                @if($conversation->latestMessage)
+                                                    <p class="truncate">
+                                                        <span class="font-semibold">{{ $conversation->latestMessage->user_id == Auth::id() ? 'Vous' : $conversation->latestMessage->user->name }}:</span>
+                                                        {{ $conversation->latestMessage->content }}
+                                                    </p>
+                                                @else
+                                                    <p class="text-gray-500 italic">Aucun message pour le moment.</p>
+                                                @endif
+                                            </div>
+                                        </div>
+                                    </div>
+                                </a>
+                            @endforeach
+                        </div>
+                    @endif
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/pifpaf/resources/views/conversations/show.blade.php
+++ b/pifpaf/resources/views/conversations/show.blade.php
@@ -1,0 +1,58 @@
+<x-app-layout>
+    <x-slot name="header">
+        <div class="flex items-center space-x-4">
+            @if($conversation->item && $conversation->item->primaryImage)
+                <img src="{{ asset('storage/' . $conversation->item->primaryImage->path) }}" alt="{{ $conversation->item->title }}" class="w-12 h-12 rounded-md object-cover">
+            @endif
+            <div>
+                <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+                    {{ $conversation->item->title ?? 'Conversation' }}
+                </h2>
+                @php
+                    $otherParticipant = $conversation->buyer_id == Auth::id() ? $conversation->seller : $conversation->buyer;
+                @endphp
+                <p class="text-sm text-gray-500">
+                    Conversation avec {{ $otherParticipant->name }}
+                </p>
+            </div>
+        </div>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 bg-white border-b border-gray-200">
+                    <!-- Messages -->
+                    <div class="space-y-4 mb-6">
+                        @forelse($conversation->messages as $message)
+                            <div class="flex {{ $message->user_id == Auth::id() ? 'justify-end' : 'justify-start' }}">
+                                <div class="max-w-lg px-4 py-2 rounded-lg {{ $message->user_id == Auth::id() ? 'bg-blue-500 text-white' : 'bg-gray-200 text-gray-800' }}">
+                                    <p>{{ $message->content }}</p>
+                                    <span class="text-xs {{ $message->user_id == Auth::id() ? 'text-blue-100' : 'text-gray-500' }} mt-1 block text-right">
+                                        {{ $message->created_at->format('H:i') }}
+                                    </span>
+                                </div>
+                            </div>
+                        @empty
+                            <p class="text-center text-gray-500">Aucun message dans cette conversation. Soyez le premier à en envoyer un !</p>
+                        @endforelse
+                    </div>
+
+                    <!-- Formulaire pour envoyer un message -->
+                    <div class="mt-8 pt-6 border-t">
+                        <form action="{{ route('messages.store', $conversation) }}" method="POST">
+                            @csrf
+                            <div class="flex items-center">
+                                <textarea name="content" rows="2" class="w-full px-4 py-2 border rounded-l-md" placeholder="Écrivez votre message..." required></textarea>
+                                <button type="submit" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-3 px-6 rounded-r-md">
+                                    Envoyer
+                                </button>
+                            </div>
+                        </form>
+                    </div>
+
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/pifpaf/resources/views/items/show.blade.php
+++ b/pifpaf/resources/views/items/show.blade.php
@@ -56,9 +56,22 @@
 
                 <div class="flex items-center justify-between">
                     <span class="font-bold text-3xl">{{ $item->price }} €</span>
-                    <button class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-3 px-6 rounded">
-                        Acheter
-                    </button>
+                    <div class="flex space-x-2">
+                        @auth
+                            @if(Auth::id() !== $item->user_id)
+                                <form action="{{ route('conversations.store') }}" method="POST">
+                                    @csrf
+                                    <input type="hidden" name="item_id" value="{{ $item->id }}">
+                                    <button type="submit" class="bg-gray-500 hover:bg-gray-700 text-white font-bold py-3 px-6 rounded">
+                                        Contacter le vendeur
+                                    </button>
+                                </form>
+                            @endif
+                        @endauth
+                        <button class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-3 px-6 rounded">
+                            Acheter
+                        </button>
+                    </div>
                 </div>
 
                 {{-- Section pour faire une offre --}}

--- a/pifpaf/resources/views/layouts/navigation.blade.php
+++ b/pifpaf/resources/views/layouts/navigation.blade.php
@@ -56,6 +56,9 @@
                              @click.away="open = false"
                              class="absolute right-0 mt-2 w-48 rounded-md shadow-lg py-1 bg-white ring-1 ring-black ring-opacity-5"
                              x-transition>
+                            <a href="{{ route('conversations.index') }}" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">
+                                Messagerie
+                            </a>
                             <!-- Authentication -->
                             <form method="POST" action="{{ route('logout') }}" dusk="logout-form">
                                 @csrf
@@ -76,7 +79,7 @@
 
             <!-- Hamburger -->
             <div class="-mr-2 flex items-center sm:hidden">
-                <button @click="open = ! open" class="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:bg-gray-100 focus:text-gray-500 transition duration-150 ease-in-out">
+                <button @click="open = ! open" dusk="hamburger-button" class="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:bg-gray-100 focus:text-gray-500 transition duration-150 ease-in-out">
                     <svg class="h-6 w-6" stroke="currentColor" fill="none" viewBox="0 0 24 24">
                         <path :class="{'hidden': open, 'inline-flex': ! open }" class="inline-flex" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
                         <path :class="{'hidden': ! open, 'inline-flex': open }" class="hidden" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
@@ -104,6 +107,9 @@
                 </a>
                 <a href="{{ route('profile.addresses.index') }}" class="block pl-3 pr-4 py-2 border-l-4 border-transparent text-base font-medium text-gray-600 hover:text-gray-800 hover:bg-gray-50 hover:border-gray-300 focus:outline-none focus:text-gray-800 focus:bg-gray-50 focus:border-gray-300 transition duration-150 ease-in-out">
                     Mes Adresses
+                </a>
+                <a href="{{ route('conversations.index') }}" class="block pl-3 pr-4 py-2 border-l-4 border-transparent text-base font-medium text-gray-600 hover:text-gray-800 hover:bg-gray-50 hover:border-gray-300 focus:outline-none focus:text-gray-800 focus:bg-gray-50 focus:border-gray-300 transition duration-150 ease-in-out">
+                    Messagerie
                 </a>
             </div>
 

--- a/pifpaf/routes/web.php
+++ b/pifpaf/routes/web.php
@@ -63,6 +63,10 @@ Route::middleware('auth')->group(function () {
 
     // Routes pour la gestion des adresses de retrait
     Route::resource('profile/addresses', PickupAddressController::class)->names('profile.addresses');
+
+    // Routes pour la messagerie
+    Route::resource('conversations', \App\Http\Controllers\ConversationController::class)->only(['index', 'show', 'store']);
+    Route::post('conversations/{conversation}/messages', [\App\Http\Controllers\MessageController::class, 'store'])->name('messages.store');
 });
 
 Route::get('/items/{item}', [ItemController::class, 'show'])->name('items.show');

--- a/pifpaf/tests/Browser/ConversationDuskTest.php
+++ b/pifpaf/tests/Browser/ConversationDuskTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Browser;
+
+use App\Models\Item;
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Laravel\Dusk\Browser;
+use Tests\DuskTestCase;
+
+class ConversationDuskTest extends DuskTestCase
+{
+    use DatabaseMigrations;
+
+    public function test_a_user_can_start_a_conversation_and_send_a_message(): void
+    {
+        $seller = User::factory()->create();
+        $buyer = User::factory()->create();
+        $item = Item::factory()->create(['user_id' => $seller->id]);
+
+        $this->browse(function (Browser $browser) use ($buyer, $item) {
+            $browser->loginAs($buyer)
+                    ->visit(route('items.show', $item))
+                    ->press('Contacter le vendeur')
+                    ->assertPathIs('/conversations/*')
+                    ->assertSee($item->title)
+                    ->type('content', 'Bonjour, cet article est-il toujours disponible ?')
+                    ->press('Envoyer')
+                    ->assertSee('Bonjour, cet article est-il toujours disponible ?');
+        });
+    }
+}

--- a/pifpaf/tests/Browser/MobileNavigationTest.php
+++ b/pifpaf/tests/Browser/MobileNavigationTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Browser;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Laravel\Dusk\Browser;
+use Tests\DuskTestCase;
+
+class MobileNavigationTest extends DuskTestCase
+{
+    use DatabaseMigrations;
+
+    public function test_messaging_link_is_visible_and_functional_in_mobile_menu(): void
+    {
+        $user = User::factory()->create();
+
+        $this->browse(function (Browser $browser) use ($user) {
+            $browser->resize(375, 812) // Simuler une taille d'iPhone X
+                    ->loginAs($user)
+                    ->visit('/dashboard')
+                    ->click('@hamburger-button') // Clic sur le bouton du menu hamburger via son attribut dusk
+                    ->waitForText('Messagerie') // Attendre que le menu s'ouvre et que le lien soit visible
+                    ->clickLink('Messagerie')
+                    ->assertPathIs('/conversations');
+        });
+    }
+}

--- a/pifpaf/tests/Feature/ConversationTest.php
+++ b/pifpaf/tests/Feature/ConversationTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Conversation;
+use App\Models\Item;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ConversationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_an_authenticated_user_can_start_a_conversation()
+    {
+        $seller = User::factory()->create();
+        $buyer = User::factory()->create();
+        $item = Item::factory()->create(['user_id' => $seller->id]);
+
+        $response = $this->actingAs($buyer)->post(route('conversations.store'), ['item_id' => $item->id]);
+
+        $response->assertRedirect();
+        $this->assertDatabaseHas('conversations', [
+            'item_id' => $item->id,
+            'buyer_id' => $buyer->id,
+            'seller_id' => $seller->id,
+        ]);
+    }
+
+    public function test_a_user_can_see_their_conversations()
+    {
+        $user = User::factory()->create();
+        $item = Item::factory()->create();
+        $conversation = Conversation::factory()->create(['buyer_id' => $user->id, 'item_id' => $item->id]);
+
+
+        $response = $this->actingAs($user)->get(route('conversations.index'));
+
+        $response->assertOk();
+        $response->assertSee($conversation->item->title);
+    }
+
+    public function test_a_user_can_send_a_message_in_a_conversation()
+    {
+        $user = User::factory()->create();
+        $conversation = Conversation::factory()->create(['buyer_id' => $user->id]);
+
+        $response = $this->actingAs($user)->post(route('messages.store', $conversation), [
+            'content' => 'This is a test message.',
+        ]);
+
+        $response->assertRedirect();
+        $this->assertDatabaseHas('messages', [
+            'conversation_id' => $conversation->id,
+            'user_id' => $user->id,
+            'content' => 'This is a test message.',
+        ]);
+    }
+
+    public function test_a_user_cannot_see_a_conversation_they_are_not_part_of()
+    {
+        $user = User::factory()->create();
+        $conversation = Conversation::factory()->create();
+
+        $response = $this->actingAs($user)->get(route('conversations.show', $conversation));
+
+        $response->assertForbidden();
+    }
+
+    public function test_a_user_cannot_send_a_message_in_a_conversation_they_are_not_part_of()
+    {
+        $user = User::factory()->create();
+        $conversation = Conversation::factory()->create();
+
+        $response = $this->actingAs($user)->post(route('messages.store', $conversation), [
+            'content' => 'This is a test message.',
+        ]);
+
+        $response->assertForbidden();
+    }
+}


### PR DESCRIPTION
Ajoute le lien vers la messagerie dans le menu de navigation responsive pour les appareils mobiles.

Ce correctif résout une omission de la précédente implémentation où le lien "Messagerie" n'était accessible que sur la version bureau du site.

- Ajout du lien dans `navigation.blade.php`.
- Ajout d'un test Dusk (`MobileNavigationTest`) pour vérifier la présence et la fonctionnalité du lien en vue mobile.
- Ajout d'un attribut `dusk` sur le bouton hamburger pour améliorer la robustesse des tests.