### PR TITLE
feat(items): Implémente les options de livraison sur les annonces

### DIFF
--- a/doc/todo.md
+++ b/doc/todo.md
@@ -25,9 +25,9 @@
 ---
 ## 🚀 Sprint 4: Logistique Avancée
 
-### Ligne de Développement: Jules 1 (Configuration Vendeur)
+### Ligne de Développement: Jules 1 (Configuration Venteur)
 - [x] **US-LOG-1:** Créer l'interface de gestion des adresses de retrait.
-- [ ] **US-LOG-2:** Permettre d'activer les options de livraison sur une annonce.
+- [x] **US-LOG-2:** Permettre d'activer les options de livraison sur une annonce.
 
 ### Ligne de Développement: Jules 2 (Parcours Acheteur)
 - [ ] **US-LOG-3:** Afficher les modes de livraison sur la page annonce.

--- a/pifpaf/app/Models/Item.php
+++ b/pifpaf/app/Models/Item.php
@@ -23,6 +23,8 @@ class Item extends Model
         'price',
         'status',
         'pickup_available',
+        'delivery_available',
+        'pickup_address_id',
         'user_id',
     ];
 
@@ -81,5 +83,13 @@ class Item extends Model
                     return $item->images()->first();
                 }
             });
+    }
+
+    /**
+     * Obtenir l'adresse de retrait de l'annonce.
+     */
+    public function pickupAddress()
+    {
+        return $this->belongsTo(PickupAddress::class);
     }
 }

--- a/pifpaf/database/migrations/2025_11_02_155555_add_delivery_options_to_items_table.php
+++ b/pifpaf/database/migrations/2025_11_02_155555_add_delivery_options_to_items_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('items', function (Blueprint $table) {
+            $table->boolean('delivery_available')->default(false)->after('pickup_available');
+            $table->foreignId('pickup_address_id')->nullable()->constrained('pickup_addresses')->after('delivery_available');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('items', function (Blueprint $table) {
+            $table->dropForeign(['pickup_address_id']);
+            $table->dropColumn(['delivery_available', 'pickup_address_id']);
+        });
+    }
+};

--- a/pifpaf/resources/views/items/create.blade.php
+++ b/pifpaf/resources/views/items/create.blade.php
@@ -90,12 +90,36 @@
                         </div>
 
 
-                        <!-- Retrait sur place -->
-                        <div class="mb-4">
-                            <label for="pickup_available" class="inline-flex items-center">
-                                <input type="checkbox" name="pickup_available" id="pickup_available" class="rounded border-gray-300 text-indigo-600 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50" value="1" {{ old('pickup_available') ? 'checked' : '' }}>
-                                <span class="ml-2 text-gray-700">Retrait sur place disponible</span>
-                            </label>
+                        <div x-data="{ pickupAvailable: {{ old('pickup_available', 'false') }} }">
+                            <!-- Livraison à domicile -->
+                            <div class="mb-4">
+                                <label for="delivery_available" class="inline-flex items-center">
+                                    <input type="checkbox" name="delivery_available" id="delivery_available" class="rounded border-gray-300 text-indigo-600 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50" value="1" {{ old('delivery_available') ? 'checked' : '' }}>
+                                    <span class="ml-2 text-gray-700">Livraison à domicile disponible</span>
+                                </label>
+                            </div>
+
+                            <!-- Retrait sur place -->
+                            <div class="mb-4">
+                                <label for="pickup_available" class="inline-flex items-center">
+                                    <input type="checkbox" name="pickup_available" id="pickup_available" x-model="pickupAvailable" class="rounded border-gray-300 text-indigo-600 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50" value="1" {{ old('pickup_available') ? 'checked' : '' }}>
+                                    <span class="ml-2 text-gray-700">Retrait sur place disponible</span>
+                                </label>
+                            </div>
+
+                            <!-- Sélection de l'adresse de retrait (conditionnelle) -->
+                            <div x-show="pickupAvailable" class="mb-4">
+                                <label for="pickup_address_id" class="block text-gray-700 text-sm font-bold mb-2">Adresse de retrait</label>
+                                <select name="pickup_address_id" id="pickup_address_id" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline">
+                                    <option value="">-- Choisir une adresse --</option>
+                                    @foreach($pickupAddresses as $address)
+                                        <option value="{{ $address->id }}" {{ old('pickup_address_id') == $address->id ? 'selected' : '' }}>
+                                            {{ $address->name }} - {{ $address->address }}, {{ $address->city }}, {{ $address->zip_code }}
+                                        </option>
+                                    @endforeach
+                                </select>
+                                <a href="{{ route('profile.addresses.create') }}" class="text-sm text-blue-500 hover:text-blue-700 mt-1 inline-block">Ajouter une nouvelle adresse</a>
+                            </div>
                         </div>
 
                         <!-- Bouton de soumission -->

--- a/pifpaf/resources/views/items/edit.blade.php
+++ b/pifpaf/resources/views/items/edit.blade.php
@@ -101,12 +101,36 @@
                             </div>
                         </div>
 
-                        <!-- Retrait sur place -->
-                        <div class="mb-4">
-                            <label for="pickup_available" class="inline-flex items-center">
-                                <input type="checkbox" name="pickup_available" id="pickup_available" class="rounded border-gray-300 text-indigo-600 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50" value="1" @if(old('pickup_available', $item->pickup_available)) checked @endif>
-                                <span class="ml-2 text-gray-700">Retrait sur place disponible</span>
-                            </label>
+                        <div x-data="{ pickupAvailable: {{ old('pickup_available', $item->pickup_available ? 'true' : 'false') }} }">
+                            <!-- Livraison à domicile -->
+                            <div class="mb-4">
+                                <label for="delivery_available" class="inline-flex items-center">
+                                    <input type="checkbox" name="delivery_available" id="delivery_available" class="rounded border-gray-300 text-indigo-600 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50" value="1" @if(old('delivery_available', $item->delivery_available)) checked @endif>
+                                    <span class="ml-2 text-gray-700">Livraison à domicile disponible</span>
+                                </label>
+                            </div>
+
+                            <!-- Retrait sur place -->
+                            <div class="mb-4">
+                                <label for="pickup_available" class="inline-flex items-center">
+                                    <input type="checkbox" name="pickup_available" id="pickup_available" x-model="pickupAvailable" class="rounded border-gray-300 text-indigo-600 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50" value="1" @if(old('pickup_available', $item->pickup_available)) checked @endif>
+                                    <span class="ml-2 text-gray-700">Retrait sur place disponible</span>
+                                </label>
+                            </div>
+
+                            <!-- Sélection de l'adresse de retrait (conditionnelle) -->
+                            <div x-show="pickupAvailable" class="mb-4">
+                                <label for="pickup_address_id" class="block text-gray-700 text-sm font-bold mb-2">Adresse de retrait</label>
+                                <select name="pickup_address_id" id="pickup_address_id" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline">
+                                    <option value="">-- Choisir une adresse --</option>
+                                    @foreach($pickupAddresses as $address)
+                                        <option value="{{ $address->id }}" @if(old('pickup_address_id', $item->pickup_address_id) == $address->id) selected @endif>
+                                            {{ $address->name }} - {{ $address->address }}, {{ $address->city }}, {{ $address->zip_code }}
+                                        </option>
+                                    @endforeach
+                                </select>
+                                <a href="{{ route('profile.addresses.create') }}" class="text-sm text-blue-500 hover:text-blue-700 mt-1 inline-block">Ajouter une nouvelle adresse</a>
+                            </div>
                         </div>
 
                         <!-- Bouton de soumission -->

--- a/pifpaf/tests/Feature/ItemDeliveryOptionsTest.php
+++ b/pifpaf/tests/Feature/ItemDeliveryOptionsTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+use App\Models\User;
+use App\Models\Item;
+use App\Models\PickupAddress;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+
+class ItemDeliveryOptionsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_can_create_item_with_delivery_options(): void
+    {
+        Storage::fake('public');
+        $user = User::factory()->create();
+        $pickupAddress = PickupAddress::factory()->create(['user_id' => $user->id]);
+
+        $response = $this->actingAs($user)->post(route('items.store'), [
+            'title' => 'Test Item',
+            'description' => 'Test Description',
+            'category' => 'Sport',
+            'price' => 100,
+            'images' => [UploadedFile::fake()->image('item.jpg')],
+            'delivery_available' => true,
+            'pickup_available' => true,
+            'pickup_address_id' => $pickupAddress->id,
+        ]);
+
+        $response->assertRedirect(route('dashboard'));
+        $this->assertDatabaseHas('items', [
+            'title' => 'Test Item',
+            'delivery_available' => true,
+            'pickup_available' => true,
+            'pickup_address_id' => $pickupAddress->id,
+        ]);
+    }
+
+    public function test_can_update_item_with_delivery_options(): void
+    {
+        $user = User::factory()->create();
+        $item = Item::factory()->create(['user_id' => $user->id]);
+        $pickupAddress = PickupAddress::factory()->create(['user_id' => $user->id]);
+
+        $response = $this->actingAs($user)->put(route('items.update', $item), [
+            'title' => 'Updated Title',
+            'description' => $item->description,
+            'category' => $item->category,
+            'price' => $item->price,
+            'delivery_available' => false,
+            'pickup_available' => true,
+            'pickup_address_id' => $pickupAddress->id,
+        ]);
+
+        $response->assertRedirect(route('dashboard'));
+        $this->assertDatabaseHas('items', [
+            'id' => $item->id,
+            'title' => 'Updated Title',
+            'delivery_available' => false,
+            'pickup_available' => true,
+            'pickup_address_id' => $pickupAddress->id,
+        ]);
+    }
+
+    public function test_pickup_address_is_required_when_pickup_is_available(): void
+    {
+        Storage::fake('public');
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->post(route('items.store'), [
+            'title' => 'Test Item',
+            'description' => 'Test Description',
+            'category' => 'Sport',
+            'price' => 100,
+            'images' => [UploadedFile::fake()->image('item.jpg')],
+            'pickup_available' => true,
+            'pickup_address_id' => null,
+        ]);
+
+        $response->assertSessionHasErrors('pickup_address_id');
+    }
+
+    public function test_item_is_created_without_pickup_address_if_pickup_is_unavailable(): void
+    {
+        Storage::fake('public');
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->post(route('items.store'), [
+            'title' => 'Another Test Item',
+            'description' => 'Test Description',
+            'category' => 'Maison',
+            'price' => 50,
+            'images' => [UploadedFile::fake()->image('item2.jpg')],
+            'delivery_available' => true,
+            'pickup_available' => false,
+            'pickup_address_id' => null, // Should be ignored
+        ]);
+
+        $response->assertRedirect(route('dashboard'));
+        $this->assertDatabaseHas('items', [
+            'title' => 'Another Test Item',
+            'delivery_available' => true,
+            'pickup_available' => false,
+            'pickup_address_id' => null,
+        ]);
+    }
+}

--- a/pifpaf/tests/Feature/PickupAvailableTest.php
+++ b/pifpaf/tests/Feature/PickupAvailableTest.php
@@ -5,9 +5,12 @@ namespace Tests\Feature;
 use App\Models\Item;
 use App\Models\Offer;
 use App\Models\Transaction;
+use App\Models\PickupAddress;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
@@ -18,7 +21,9 @@ class PickupAvailableTest extends TestCase
     #[Test]
     public function pickup_available_option_is_saved_when_creating_an_item(): void
     {
+        Storage::fake('public');
         $user = User::factory()->create();
+        $pickupAddress = PickupAddress::factory()->create(['user_id' => $user->id]);
         $this->actingAs($user);
 
         $itemData = [
@@ -26,8 +31,9 @@ class PickupAvailableTest extends TestCase
             'description' => 'Une super description',
             'category' => 'Vêtements',
             'price' => 10,
-            'image_path' => 'images/test.jpg',
+            'images' => [UploadedFile::fake()->image('photo.jpg')],
             'pickup_available' => true,
+            'pickup_address_id' => $pickupAddress->id,
         ];
 
         $this->post(route('items.store'), $itemData);
@@ -35,6 +41,7 @@ class PickupAvailableTest extends TestCase
         $this->assertDatabaseHas('items', [
             'title' => 'Mon article',
             'pickup_available' => true,
+            'pickup_address_id' => $pickupAddress->id,
         ]);
     }
 


### PR DESCRIPTION
Ajoute la possibilité pour les vendeurs d'activer la livraison à domicile et/ou le retrait sur place pour leurs annonces.

- Ajoute les colonnes `delivery_available` (boolean) et `pickup_address_id` (foreign key) à la table `items` via une nouvelle migration.
- Met à jour le modèle `Item`, le `ItemController` et les vues `create`/`edit` pour gérer ces nouvelles options.
- La sélection de l'adresse de retrait n'apparaît que si l'option "Retrait sur place" est activée, grâce à Alpine.js.
- Ajoute un test de fonctionnalité (`ItemDeliveryOptionsTest`) pour valider la création et la mise à jour des annonces avec ces options.
- Corrige un test préexistant (`PickupAvailableTest`) qui échouait à cause de la nouvelle règle de validation.