### PR TITLE
feat(profile): display average rating and reviews on public profiles

### DIFF
--- a/pifpaf/app/Http/Controllers/ProfileController.php
+++ b/pifpaf/app/Http/Controllers/ProfileController.php
@@ -12,7 +12,11 @@ class ProfileController extends Controller
      */
     public function show(User $user)
     {
-        $user->load('items');
-        return view('profile.show', compact('user'));
+        $user->load('items', 'reviewsReceived.reviewer');
+
+        $averageRating = $user->reviewsReceived->avg('rating');
+        $reviewCount = $user->reviewsReceived->count();
+
+        return view('profile.show', compact('user', 'averageRating', 'reviewCount'));
     }
 }

--- a/pifpaf/app/Models/User.php
+++ b/pifpaf/app/Models/User.php
@@ -94,6 +94,8 @@ class User extends Authenticatable
     public function reviewsReceived()
     {
         return $this->hasMany(Review::class, 'reviewee_id');
+    }
+
     /**
      * Vérifie si l'utilisateur est banni.
      *

--- a/pifpaf/resources/views/profile/show.blade.php
+++ b/pifpaf/resources/views/profile/show.blade.php
@@ -3,10 +3,33 @@
         <div class="bg-white rounded-lg shadow-md overflow-hidden p-8">
             <h1 class="text-4xl font-bold mb-2">{{ $user->name }}</h1>
 
-            {{-- Placeholder for ratings and reviews from US17 --}}
+            {{-- Ratings and reviews --}}
             <div class="mb-6">
-                <span class="text-gray-500">Note moyenne :</span>
-                <span class="font-semibold">N/A</span>
+                @if ($reviewCount > 0)
+                    <div class="flex items-center">
+                        <span class="text-gray-500 mr-2">Note moyenne :</span>
+                        <span class="font-semibold text-yellow-500">{{ number_format($averageRating, 1) }} / 5</span>
+                        <span class="text-gray-400 ml-2">({{ $reviewCount }} avis)</span>
+                    </div>
+                @else
+                    <p class="text-gray-500">Aucun avis pour le moment.</p>
+                @endif
+            </div>
+
+            <div class="mt-8 pt-8 border-t">
+                <h2 class="text-2xl font-bold mb-4">Avis reçus</h2>
+                @forelse($user->reviewsReceived as $review)
+                    <div class="border-b py-4">
+                        <div class="flex items-center mb-2">
+                            <span class="font-semibold">{{ $review->reviewer->name }}</span>
+                            <span class="text-gray-400 mx-2">-</span>
+                            <span class="text-yellow-500 font-bold">{{ $review->rating }}/5</span>
+                        </div>
+                        <p class="text-gray-700">{{ $review->comment }}</p>
+                    </div>
+                @empty
+                    <p>Cet utilisateur n'a pas encore reçu d'avis.</p>
+                @endforelse
             </div>
 
             <div class="mt-8 pt-8 border-t">

--- a/pifpaf/tests/Feature/ProfilePageTest.php
+++ b/pifpaf/tests/Feature/ProfilePageTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Item;
+use App\Models\Offer;
+use App\Models\Transaction;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use App\Models\User;
+use App\Models\Review;
+
+class ProfilePageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function it_displays_user_average_rating_and_reviews()
+    {
+        // 1. Arrange
+        // Créer l'utilisateur vendeur (celui qui est noté)
+        $reviewee = User::factory()->create();
+        $item = Item::factory()->create(['user_id' => $reviewee->id]);
+
+        // Créer le premier acheteur et sa transaction/avis
+        $reviewer1 = User::factory()->create();
+        $offer1 = Offer::factory()->create(['item_id' => $item->id, 'user_id' => $reviewer1->id]);
+        $transaction1 = Transaction::factory()->create(['offer_id' => $offer1->id]);
+        $review1 = Review::factory()->create([
+            'transaction_id' => $transaction1->id,
+            'reviewee_id' => $reviewee->id,
+            'reviewer_id' => $reviewer1->id,
+            'rating' => 4,
+            'comment' => 'Super vendeur, communication au top !',
+        ]);
+
+        // Créer le second acheteur et sa transaction/avis
+        $reviewer2 = User::factory()->create();
+        $offer2 = Offer::factory()->create(['item_id' => $item->id, 'user_id' => $reviewer2->id]);
+        $transaction2 = Transaction::factory()->create(['offer_id' => $offer2->id]);
+        $review2 = Review::factory()->create([
+            'transaction_id' => $transaction2->id,
+            'reviewee_id' => $reviewee->id,
+            'reviewer_id' => $reviewer2->id,
+            'rating' => 5,
+            'comment' => 'Transaction parfaite, je recommande.',
+        ]);
+
+        // 2. Act
+        $response = $this->get(route('profile.show', $reviewee));
+
+        // 3. Assert
+        $response->assertStatus(200);
+
+        // Vérifier la note moyenne et le nombre d'avis
+        $response->assertSee('Note moyenne :');
+        $response->assertSee('4.5 / 5');
+        $response->assertSee('(2 avis)');
+
+        // Vérifier que les détails des avis sont affichés
+        $response->assertSee($reviewer1->name);
+        $response->assertSee('4/5');
+        $response->assertSee('Super vendeur, communication au top !');
+
+        $response->assertSee($reviewer2->name);
+        $response->assertSee('5/5');
+        $response->assertSee('Transaction parfaite, je recommande.');
+    }
+
+    /** @test */
+    public function it_displays_a_message_when_there_are_no_reviews()
+    {
+        // 1. Arrange
+        $userWithoutReviews = User::factory()->create();
+
+        // 2. Act
+        $response = $this->get(route('profile.show', $userWithoutReviews));
+
+        // 3. Assert
+        $response->assertStatus(200);
+        $response->assertSee('Aucun avis pour le moment.');
+        $response->assertDontSee('Note moyenne :');
+    }
+}


### PR DESCRIPTION
This commit implements the User Story US-COM-2.

It introduces the following changes:
- Updates the `ProfileController` to load and calculate the average rating and review count for a user.
- Modifies the `profile.show` view to display these new statistics and a detailed list of all received reviews.
- Adds a feature test (`ProfilePageTest`) to validate the functionality and cover edge cases (e.g., users with no reviews).
- Fixes a pre-existing syntax error (missing closing brace) in the `User` model that was discovered during testing.