### PR TITLE
Refactor(view): Extrait le formulaire d'annonce dans un composant Blade

### DIFF
--- a/pifpaf/resources/views/components/item-form.blade.php
+++ b/pifpaf/resources/views/components/item-form.blade.php
@@ -1,0 +1,93 @@
+@props([
+    'item' => null,
+    'action',
+    'method' => 'POST',
+    'submitText'
+])
+
+<form action="{{ $action }}" method="POST" enctype="multipart/form-data">
+    @csrf
+    @if(strtoupper($method) !== 'POST')
+        @method($method)
+    @endif
+
+    @if(session('image_path'))
+        <input type="hidden" name="image_path" value="{{ session('image_path') }}">
+    @endif
+
+    <!-- Titre -->
+    <div class="mb-4">
+        <label for="title" class="block text-gray-700 text-sm font-bold mb-2">Titre</label>
+        <input type="text" name="title" id="title" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" value="{{ old('title', $item->title ?? session('ai_data')['title'] ?? '') }}" required>
+    </div>
+
+    <!-- Description -->
+    <div class="mb-4">
+        <label for="description" class="block text-gray-700 text-sm font-bold mb-2">Description</label>
+        <textarea name="description" id="description" rows="4" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" required>{{ old('description', $item->description ?? session('ai_data')['description'] ?? '') }}</textarea>
+    </div>
+
+    <!-- Catégorie -->
+    <div class="mb-4">
+        <label for="category" class="block text-gray-700 text-sm font-bold mb-2">Catégorie</label>
+        <select name="category" id="category" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" required>
+            <option value="">-- Choisir une catégorie --</option>
+            @php
+                $selectedCategory = old('category', $item->category ?? session('ai_data')['category'] ?? '');
+                $categories = ['Vêtements', 'Électronique', 'Maison', 'Sport', 'Loisirs', 'Autre'];
+            @endphp
+            @foreach($categories as $category)
+                <option value="{{ $category }}" @if($selectedCategory == $category) selected @endif>{{ $category }}</option>
+            @endforeach
+        </select>
+    </div>
+
+    <!-- Prix -->
+    <div class="mb-4">
+        <label for="price" class="block text-gray-700 text-sm font-bold mb-2">Prix</label>
+        <input type="number" step="0.01" name="price" id="price" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" value="{{ old('price', $item->price ?? session('ai_data')['price'] ?? '') }}" required>
+    </div>
+
+    <!-- Slot pour les images -->
+    {{ $images }}
+
+
+    <div x-data="{ pickupAvailable: {{ old('pickup_available', $item->pickup_available ?? false) ? 'true' : 'false' }} }">
+        <!-- Livraison à domicile -->
+        <div class="mb-4">
+            <label for="delivery_available" class="inline-flex items-center">
+                <input type="checkbox" name="delivery_available" id="delivery_available" class="rounded border-gray-300 text-indigo-600 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50" value="1" @if(old('delivery_available', $item->delivery_available ?? false)) checked @endif>
+                <span class="ml-2 text-gray-700">Livraison à domicile disponible</span>
+            </label>
+        </div>
+
+        <!-- Retrait sur place -->
+        <div class="mb-4">
+            <label for="pickup_available" class="inline-flex items-center">
+                <input type="checkbox" name="pickup_available" id="pickup_available" x-model="pickupAvailable" class="rounded border-gray-300 text-indigo-600 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50" value="1" @if(old('pickup_available', $item->pickup_available ?? false)) checked @endif>
+                <span class="ml-2 text-gray-700">Retrait sur place disponible</span>
+            </label>
+        </div>
+
+        <!-- Sélection de l'adresse de retrait (conditionnelle) -->
+        <div x-show="pickupAvailable" class="mb-4">
+            <label for="pickup_address_id" class="block text-gray-700 text-sm font-bold mb-2">Adresse de retrait</label>
+            <select name="pickup_address_id" id="pickup_address_id" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline">
+                <option value="">-- Choisir une adresse --</option>
+                @foreach($pickupAddresses as $address)
+                    <option value="{{ $address->id }}" @if(old('pickup_address_id', $item->pickup_address_id ?? null) == $address->id) selected @endif>
+                        {{ $address->name }} - {{ $address->address }}, {{ $address->city }}, {{ $address->zip_code }}
+                    </option>
+                @endforeach
+            </select>
+            <a href="{{ route('profile.addresses.create') }}" class="text-sm text-blue-500 hover:text-blue-700 mt-1 inline-block">Ajouter une nouvelle adresse</a>
+        </div>
+    </div>
+
+    <!-- Bouton de soumission -->
+    <div class="flex items-center justify-end mt-4">
+        <button type="submit" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline">
+            {{ $submitText }}
+        </button>
+    </div>
+</form>

--- a/pifpaf/resources/views/items/create.blade.php
+++ b/pifpaf/resources/views/items/create.blade.php
@@ -20,7 +20,6 @@
 
                     <div class="my-4 border-t border-gray-200"></div>
 
-
                     <!-- Affichage des erreurs de validation -->
                     @if ($errors->any())
                         <div class="alert alert-danger mb-4">
@@ -32,114 +31,38 @@
                         </div>
                     @endif
 
-                    <form action="{{ route('items.store') }}" method="POST" enctype="multipart/form-data">
-                        @csrf
+                    <x-item-form
+                        :action="route('items.store')"
+                        :submit-text="session('ai_data') ? 'Mettre en vente' : 'Créer l\'annonce'"
+                        :pickup-addresses="$pickupAddresses">
 
-                        @if(session('image_path'))
-                            <input type="hidden" name="image_path" value="{{ session('image_path') }}">
-                        @endif
-
-                        <!-- Titre -->
-                        <div class="mb-4">
-                            <label for="title" class="block text-gray-700 text-sm font-bold mb-2">Titre</label>
-                            <input type="text" name="title" id="title" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" value="{{ old('title', session('ai_data')['title'] ?? '') }}" required>
-                        </div>
-
-                        <!-- Description -->
-                        <div class="mb-4">
-                            <label for="description" class="block text-gray-700 text-sm font-bold mb-2">Description</label>
-                            <textarea name="description" id="description" rows="4" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" required>{{ old('description', session('ai_data')['description'] ?? '') }}</textarea>
-                        </div>
-
-                        <!-- Catégorie -->
-                        <div class="mb-4">
-                            <label for="category" class="block text-gray-700 text-sm font-bold mb-2">Catégorie</label>
-                            <select name="category" id="category" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" required>
-                                <option value="">-- Choisir une catégorie --</option>
-                                @php
-                                    $selectedCategory = old('category', session('ai_data')['category'] ?? '');
-                                @endphp
-                                <option value="Vêtements" @if($selectedCategory == 'Vêtements') selected @endif>Vêtements</option>
-                                <option value="Électronique" @if($selectedCategory == 'Électronique') selected @endif>Électronique</option>
-                                <option value="Maison" @if($selectedCategory == 'Maison') selected @endif>Maison</option>
-                                <option value="Sport" @if($selectedCategory == 'Sport') selected @endif>Sport</option>
-                                <option value="Loisirs" @if($selectedCategory == 'Loisirs') selected @endif>Loisirs</option>
-                                <option value="Autre" @if($selectedCategory == 'Autre') selected @endif>Autre</option>
-                            </select>
-                        </div>
-
-                        <!-- Prix -->
-                        <div class="mb-4">
-                            <label for="price" class="block text-gray-700 text-sm font-bold mb-2">Prix</label>
-                            <input type="number" step="0.01" name="price" id="price" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" value="{{ old('price', session('ai_data')['price'] ?? '') }}" required>
-                        </div>
-
-                        <!-- Images -->
-                        <div class="mb-4">
-                            <label for="images" class="block text-gray-700 text-sm font-bold mb-2">Images (jusqu'à 10)</label>
-
-                            <div class="p-4 border border-dashed rounded-md">
-                                <input type="file" name="images[]" id="images" class="block w-full text-sm text-gray-500
-                                    file:mr-4 file:py-2 file:px-4
-                                    file:rounded-full file:border-0
-                                    file:text-sm file:font-semibold
-                                    file:bg-blue-50 file:text-blue-700
-                                    hover:file:bg-blue-100"
-                                    multiple
-                                    accept="image/png, image/jpeg"
-                                    {{ session('image_path') ? '' : 'required' }}>
-                            </div>
-
-                            <div id="image-preview-container" class="mt-4 flex flex-wrap gap-4">
-                                @if(session('image_path'))
-                                    <div class="relative w-32 h-32">
-                                        <img src="{{ asset('storage/' . session('image_path')) }}" class="w-full h-full object-cover rounded-md">
-                                        <p class="text-xs text-center mt-1">Image de l'IA</p>
-                                    </div>
-                                @endif
-                            </div>
-                        </div>
-
-
-                        <div x-data="{ pickupAvailable: {{ old('pickup_available', 'false') }} }">
-                            <!-- Livraison à domicile -->
+                        <x-slot name="images">
                             <div class="mb-4">
-                                <label for="delivery_available" class="inline-flex items-center">
-                                    <input type="checkbox" name="delivery_available" id="delivery_available" class="rounded border-gray-300 text-indigo-600 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50" value="1" {{ old('delivery_available') ? 'checked' : '' }}>
-                                    <span class="ml-2 text-gray-700">Livraison à domicile disponible</span>
-                                </label>
-                            </div>
+                                <label for="images" class="block text-gray-700 text-sm font-bold mb-2">Images (jusqu'à 10)</label>
 
-                            <!-- Retrait sur place -->
-                            <div class="mb-4">
-                                <label for="pickup_available" class="inline-flex items-center">
-                                    <input type="checkbox" name="pickup_available" id="pickup_available" x-model="pickupAvailable" class="rounded border-gray-300 text-indigo-600 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50" value="1" {{ old('pickup_available') ? 'checked' : '' }}>
-                                    <span class="ml-2 text-gray-700">Retrait sur place disponible</span>
-                                </label>
-                            </div>
+                                <div class="p-4 border border-dashed rounded-md">
+                                    <input type="file" name="images[]" id="images" class="block w-full text-sm text-gray-500
+                                        file:mr-4 file:py-2 file:px-4
+                                        file:rounded-full file:border-0
+                                        file:text-sm file:font-semibold
+                                        file:bg-blue-50 file:text-blue-700
+                                        hover:file:bg-blue-100"
+                                        multiple
+                                        accept="image/png, image/jpeg"
+                                        {{ session('image_path') ? '' : 'required' }}>
+                                </div>
 
-                            <!-- Sélection de l'adresse de retrait (conditionnelle) -->
-                            <div x-show="pickupAvailable" class="mb-4">
-                                <label for="pickup_address_id" class="block text-gray-700 text-sm font-bold mb-2">Adresse de retrait</label>
-                                <select name="pickup_address_id" id="pickup_address_id" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline">
-                                    <option value="">-- Choisir une adresse --</option>
-                                    @foreach($pickupAddresses as $address)
-                                        <option value="{{ $address->id }}" {{ old('pickup_address_id') == $address->id ? 'selected' : '' }}>
-                                            {{ $address->name }} - {{ $address->address }}, {{ $address->city }}, {{ $address->zip_code }}
-                                        </option>
-                                    @endforeach
-                                </select>
-                                <a href="{{ route('profile.addresses.create') }}" class="text-sm text-blue-500 hover:text-blue-700 mt-1 inline-block">Ajouter une nouvelle adresse</a>
+                                <div id="image-preview-container" class="mt-4 flex flex-wrap gap-4">
+                                    @if(session('image_path'))
+                                        <div class="relative w-32 h-32">
+                                            <img src="{{ asset('storage/' . session('image_path')) }}" class="w-full h-full object-cover rounded-md">
+                                            <p class="text-xs text-center mt-1">Image de l'IA</p>
+                                        </div>
+                                    @endif
+                                </div>
                             </div>
-                        </div>
-
-                        <!-- Bouton de soumission -->
-                        <div class="flex items-center justify-end mt-4">
-                            <button type="submit" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline">
-                                {{ session('ai_data') ? 'Mettre en vente' : 'Créer l\'annonce' }}
-                            </button>
-                        </div>
-                    </form>
+                        </x-slot>
+                    </x-item-form>
                 </div>
             </div>
         </div>

--- a/pifpaf/resources/views/items/edit.blade.php
+++ b/pifpaf/resources/views/items/edit.blade.php
@@ -21,125 +21,58 @@
                         </div>
                     @endif
 
-                    <form action="{{ route('items.update', $item) }}" method="POST" enctype="multipart/form-data">
-                        @csrf
-                        @method('PUT')
+                    <x-item-form
+                        :item="$item"
+                        :action="route('items.update', $item)"
+                        method="PUT"
+                        submit-text="Mettre à jour"
+                        :pickup-addresses="$pickupAddresses">
 
-                        <!-- Titre -->
-                        <div class="mb-4">
-                            <label for="title" class="block text-gray-700 text-sm font-bold mb-2">Titre</label>
-                            <input type="text" name="title" id="title" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" value="{{ old('title', $item->title) }}" required>
-                        </div>
+                        <x-slot name="images">
+                            <div class="mb-4">
+                                <label class="block text-gray-700 text-sm font-bold mb-2">Images (jusqu'à 10)</label>
 
-                        <!-- Description -->
-                        <div class="mb-4">
-                            <label for="description" class="block text-gray-700 text-sm font-bold mb-2">Description</label>
-                            <textarea name="description" id="description" rows="4" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" required>{{ old('description', $item->description) }}</textarea>
-                        </div>
-
-                        <!-- Catégorie -->
-                        <div class="mb-4">
-                            <label for="category" class="block text-gray-700 text-sm font-bold mb-2">Catégorie</label>
-                            <select name="category" id="category" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" required>
-                                <option value="">-- Choisir une catégorie --</option>
-                                <option value="Vêtements" @if(old('category', $item->category) == 'Vêtements') selected @endif>Vêtements</option>
-                                <option value="Électronique" @if(old('category', $item->category) == 'Électronique') selected @endif>Électronique</option>
-                                <option value="Maison" @if(old('category', $item->category) == 'Maison') selected @endif>Maison</option>
-                                <option value="Sport" @if(old('category', $item->category) == 'Sport') selected @endif>Sport</option>
-                                <option value="Loisirs" @if(old('category', $item->category) == 'Loisirs') selected @endif>Loisirs</option>
-                                <option value="Autre" @if(old('category', $item->category) == 'Autre') selected @endif>Autre</option>
-                            </select>
-                        </div>
-
-                        <!-- Prix -->
-                        <div class="mb-4">
-                            <label for="price" class="block text-gray-700 text-sm font-bold mb-2">Prix</label>
-                            <input type="number" step="0.01" name="price" id="price" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" value="{{ old('price', $item->price) }}" required>
-                        </div>
-
-                        <!-- Images -->
-                        <div class="mb-4">
-                            <label for="images" class="block text-gray-700 text-sm font-bold mb-2">Images (jusqu'à 10)</label>
-
-                            <!-- Affichage des images existantes -->
-                            <div id="existing-images-container" class="mt-4 flex flex-wrap gap-4">
-                                @foreach($item->images as $image)
-                                    <div id="image-{{ $image->id }}" data-id="{{ $image->id }}" class="relative w-32 h-32 group cursor-move">
-                                        <img src="{{ asset('storage/' . $image->path) }}" class="w-full h-full object-cover rounded-md @if($image->is_primary) border-4 border-blue-500 @endif">
-                                        <div class="absolute inset-0 bg-black bg-opacity-50 flex flex-col items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity">
-                                            @if(!$image->is_primary)
+                                <!-- Affichage des images existantes -->
+                                <div id="existing-images-container" class="mt-4 flex flex-wrap gap-4">
+                                    @foreach($item->images as $image)
+                                        <div id="image-{{ $image->id }}" data-id="{{ $image->id }}" class="relative w-32 h-32 group cursor-move">
+                                            <img src="{{ asset('storage/' . $image->path) }}" class="w-full h-full object-cover rounded-md @if($image->is_primary) border-4 border-blue-500 @endif">
+                                            <div class="absolute inset-0 bg-black bg-opacity-50 flex flex-col items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity">
+                                                @if(!$image->is_primary)
+                                                    <button type="button"
+                                                            onclick="setAsPrimary('{{ route('item-images.set-primary', $image->id) }}')"
+                                                            class="text-white text-xs bg-blue-500 hover:bg-blue-700 rounded-full px-2 py-1 mb-1">
+                                                        Principale
+                                                    </button>
+                                                @endif
                                                 <button type="button"
-                                                        onclick="setAsPrimary('{{ route('item-images.set-primary', $image->id) }}')"
-                                                        class="text-white text-xs bg-blue-500 hover:bg-blue-700 rounded-full px-2 py-1 mb-1">
-                                                    Principale
+                                                        onclick="deleteImage('{{ route('item-images.destroy', $image->id) }}')"
+                                                        class="text-white text-xs bg-red-500 hover:bg-red-700 rounded-full px-2 py-1">
+                                                    Supprimer
                                                 </button>
-                                            @endif
-                                            <button type="button"
-                                                    onclick="deleteImage('{{ route('item-images.destroy', $image->id) }}')"
-                                                    class="text-white text-xs bg-red-500 hover:bg-red-700 rounded-full px-2 py-1">
-                                                Supprimer
-                                            </button>
+                                            </div>
                                         </div>
-                                    </div>
-                                @endforeach
-                            </div>
-
-                            <div class="p-4 mt-4 border border-dashed rounded-md">
-                                <label for="images" class="block text-gray-700 text-sm font-bold mb-2">Ajouter de nouvelles images</label>
-                                <input type="file" name="images[]" id="images" class="block w-full text-sm text-gray-500
-                                    file:mr-4 file:py-2 file:px-4
-                                    file:rounded-full file:border-0
-                                    file:text-sm file:font-semibold
-                                    file:bg-blue-50 file:text-blue-700
-                                    hover:file:bg-blue-100"
-                                    multiple
-                                    accept="image/png, image/jpeg">
-                            </div>
-
-                            <div id="image-preview-container" class="mt-4 flex flex-wrap gap-4">
-                                <!-- Les prévisualisations des nouvelles images apparaîtront ici -->
-                            </div>
-                        </div>
-
-                        <div x-data="{ pickupAvailable: {{ old('pickup_available', $item->pickup_available ? 'true' : 'false') }} }">
-                            <!-- Livraison à domicile -->
-                            <div class="mb-4">
-                                <label for="delivery_available" class="inline-flex items-center">
-                                    <input type="checkbox" name="delivery_available" id="delivery_available" class="rounded border-gray-300 text-indigo-600 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50" value="1" @if(old('delivery_available', $item->delivery_available)) checked @endif>
-                                    <span class="ml-2 text-gray-700">Livraison à domicile disponible</span>
-                                </label>
-                            </div>
-
-                            <!-- Retrait sur place -->
-                            <div class="mb-4">
-                                <label for="pickup_available" class="inline-flex items-center">
-                                    <input type="checkbox" name="pickup_available" id="pickup_available" x-model="pickupAvailable" class="rounded border-gray-300 text-indigo-600 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50" value="1" @if(old('pickup_available', $item->pickup_available)) checked @endif>
-                                    <span class="ml-2 text-gray-700">Retrait sur place disponible</span>
-                                </label>
-                            </div>
-
-                            <!-- Sélection de l'adresse de retrait (conditionnelle) -->
-                            <div x-show="pickupAvailable" class="mb-4">
-                                <label for="pickup_address_id" class="block text-gray-700 text-sm font-bold mb-2">Adresse de retrait</label>
-                                <select name="pickup_address_id" id="pickup_address_id" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline">
-                                    <option value="">-- Choisir une adresse --</option>
-                                    @foreach($pickupAddresses as $address)
-                                        <option value="{{ $address->id }}" @if(old('pickup_address_id', $item->pickup_address_id) == $address->id) selected @endif>
-                                            {{ $address->name }} - {{ $address->address }}, {{ $address->city }}, {{ $address->zip_code }}
-                                        </option>
                                     @endforeach
-                                </select>
-                                <a href="{{ route('profile.addresses.create') }}" class="text-sm text-blue-500 hover:text-blue-700 mt-1 inline-block">Ajouter une nouvelle adresse</a>
-                            </div>
-                        </div>
+                                </div>
 
-                        <!-- Bouton de soumission -->
-                        <div class="flex items-center justify-end mt-4">
-                            <button type="submit" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline">
-                                Mettre à jour
-                            </button>
-                        </div>
-                    </form>
+                                <div class="p-4 mt-4 border border-dashed rounded-md">
+                                    <label for="images" class="block text-gray-700 text-sm font-bold mb-2">Ajouter de nouvelles images</label>
+                                    <input type="file" name="images[]" id="images" class="block w-full text-sm text-gray-500
+                                        file:mr-4 file:py-2 file:px-4
+                                        file:rounded-full file:border-0
+                                        file:text-sm file:font-semibold
+                                        file:bg-blue-50 file:text-blue-700
+                                        hover:file:bg-blue-100"
+                                        multiple
+                                        accept="image/png, image/jpeg">
+                                </div>
+
+                                <div id="image-preview-container" class="mt-4 flex flex-wrap gap-4">
+                                    <!-- Les prévisualisations des nouvelles images apparaîtront ici -->
+                                </div>
+                            </div>
+                        </x-slot>
+                    </x-item-form>
                 </div>
             </div>
         </div>

--- a/pifpaf/tests/Browser/ItemEditTest.php
+++ b/pifpaf/tests/Browser/ItemEditTest.php
@@ -29,7 +29,8 @@ class ItemEditTest extends DuskTestCase
         $this->browse(function (Browser $browser) use ($user, $item, $filePath) {
             $browser->loginAs($user)
                     ->visit('/dashboard')
-                    ->click('.edit-item-link') // S'assurer que le lien a cette classe
+                    // On cible le lien dans la première rangée du tableau, qui est sur le titre de l'item.
+                    ->click("#item-row-{$item->id} a")
                     ->assertPathIs("/items/{$item->id}/edit")
                     ->assertInputValue('title', $item->title)
                     ->type('title', 'Nouveau Titre d\'Annonce')


### PR DESCRIPTION
Ce commit refactorise les vues de création (`create.blade.php`) et d'édition (`edit.blade.php`) d'annonces. Le formulaire, qui était dupliqué dans les deux fichiers, a été extrait dans un composant Blade réutilisable (`<x-item-form>`).

Ce nouveau composant accepte des propriétés pour gérer les variations (action, méthode, données de l'item) et utilise un slot pour la section de gestion des images, qui diffère entre les deux vues.

Cette modification améliore la maintenabilité du code en centralisant la logique du formulaire, réduit la duplication de code et diminue la taille des fichiers de vue.

Un test Dusk (`ItemEditTest`) a également été mis à jour pour s'adapter à la nouvelle structure HTML du tableau de bord, garantissant ainsi l'absence de régression.