### PR TITLE
Corrige la route pour la création de conversation

### DIFF
--- a/pifpaf/resources/views/items/show.blade.php
+++ b/pifpaf/resources/views/items/show.blade.php
@@ -95,7 +95,9 @@
                                             Acheter
                                         </button>
                                     </form>
-                                    <form action="{{ route('conversations.create', ['item' => $item->id]) }}" method="GET">
+                                    <form action="{{ route('conversations.store') }}" method="POST">
+                                        @csrf
+                                        <input type="hidden" name="item_id" value="{{ $item->id }}">
                                         <button type="submit" class="bg-gray-500 hover:bg-gray-700 text-white font-bold py-3 px-6 rounded">
                                             Contacter le vendeur
                                         </button>


### PR DESCRIPTION
Le formulaire sur la page de détail d'un article pointait vers une route inexistante `conversations.create` avec la méthode GET.

Cette modification corrige le formulaire pour qu'il pointe vers la route `conversations.store` avec la méthode POST, ce qui est conforme aux conventions RESTful de Laravel. Ajoute également le jeton CSRF nécessaire.