### PR TITLE
feat(items): Display 'Sold' status on detail page

### DIFF
--- a/pifpaf/resources/views/items/show.blade.php
+++ b/pifpaf/resources/views/items/show.blade.php
@@ -7,8 +7,13 @@
             @if ($item->images->isNotEmpty())
                 <div x-data="{ mainImageUrl: '{{ asset('storage/' . $item->primaryImage->path) }}' }">
                     <!-- Image principale -->
-                    <div class="w-full h-96 bg-gray-200 flex items-center justify-center">
-                        <img :src="mainImageUrl" alt="{{ $item->title }}" class="w-full h-full object-contain">
+                    <div class="relative w-full h-96 bg-gray-200 flex items-center justify-center">
+                        <img :src="mainImageUrl" alt="{{ $item->title }}" class="w-full h-full object-contain {{ $item->status === \App\Enums\ItemStatus::SOLD ? 'opacity-40' : '' }}">
+                        @if ($item->status === \App\Enums\ItemStatus::SOLD)
+                            <div class="absolute inset-0 bg-black bg-opacity-50 flex items-center justify-center">
+                                <span class="text-white text-5xl font-bold transform -rotate-12 border-4 border-white p-4 rounded-lg">VENDU</span>
+                            </div>
+                        @endif
                     </div>
 
                     <!-- Galerie de miniatures -->
@@ -78,83 +83,90 @@
                     </div>
                 </div>
 
-                <div>
-                    <div class="flex items-center justify-between">
-                        <span class="font-bold text-3xl">{{ number_format($item->price, 2, ',', ' ') }} €</span>
-                        <div class="flex space-x-2">
-                            @auth
-                                @if(Auth::id() !== $item->user_id)
-                                    <form action="{{ route('offers.buyNow', $item) }}" method="POST">
-                                        @csrf
-                                        <input type="hidden" name="amount" value="{{ $item->price }}">
-                                        <input type="hidden" name="delivery_method" x-model="deliveryMethod">
-                                        <button type="submit"
-                                                class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-3 px-6 rounded"
-                                                :disabled="!deliveryMethod"
-                                                :class="{ 'opacity-50 cursor-not-allowed': !deliveryMethod }">
-                                            Acheter
-                                        </button>
-                                    </form>
-                                    <form action="{{ route('conversations.store') }}" method="POST">
-                                        @csrf
-                                        <input type="hidden" name="item_id" value="{{ $item->id }}">
-                                        <button type="submit" class="bg-gray-500 hover:bg-gray-700 text-white font-bold py-3 px-6 rounded" dusk="contact-seller-button">
-                                            Contacter le vendeur
-                                        </button>
-                                    </form>
-                                @endif
-                            @else
-                                <a href="{{ route('login', ['redirect' => url()->current()]) }}" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-3 px-6 rounded">
-                                    Acheter
-                                </a>
-                            @endauth
+                @if ($item->status !== \App\Enums\ItemStatus::SOLD)
+                    <div>
+                        <div class="flex items-center justify-between">
+                            <span class="font-bold text-3xl">{{ number_format($item->price, 2, ',', ' ') }} €</span>
+                            <div class="flex space-x-2">
+                                @auth
+                                    @if(Auth::id() !== $item->user_id)
+                                        <form action="{{ route('offers.buyNow', $item) }}" method="POST">
+                                            @csrf
+                                            <input type="hidden" name="amount" value="{{ $item->price }}">
+                                            <input type="hidden" name="delivery_method" x-model="deliveryMethod">
+                                            <button type="submit"
+                                                    class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-3 px-6 rounded"
+                                                    :disabled="!deliveryMethod"
+                                                    :class="{ 'opacity-50 cursor-not-allowed': !deliveryMethod }">
+                                                Acheter
+                                            </button>
+                                        </form>
+                                        <form action="{{ route('conversations.store') }}" method="POST">
+                                            @csrf
+                                            <input type="hidden" name="item_id" value="{{ $item->id }}">
+                                            <button type="submit" class="bg-gray-500 hover:bg-gray-700 text-white font-bold py-3 px-6 rounded" dusk="contact-seller-button">
+                                                Contacter le vendeur
+                                            </button>
+                                        </form>
+                                    @endif
+                                @else
+                                    <a href="{{ route('login', ['redirect' => url()->current()]) }}" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-3 px-6 rounded">
+                                        Acheter
+                                    </a>
+                                @endauth
+                            </div>
                         </div>
-                    </div>
-                     @auth
-                        @if(Auth::id() !== $item->user_id)
-                            <div class="mt-4 p-4 border rounded-md bg-gray-50" x-show="true">
-                                <h3 class="font-semibold text-gray-800 mb-2">Veuillez sélectionner un mode de livraison pour acheter :</h3>
-                                <div class="space-y-2">
-                                     @if ($item->pickup_available)
-                                    <label class="flex items-center p-3 border rounded-md has-[:checked]:bg-blue-50 has-[:checked]:border-blue-300 cursor-pointer">
-                                        <input type="radio" name="delivery_method_choice" value="pickup" x-model="deliveryMethod" class="h-4 w-4 text-blue-600 border-gray-300 focus:ring-blue-500" dusk="delivery-method-pickup">
-                                        <span class="ml-3 text-sm font-medium text-gray-700">Retrait sur place</span>
-                                    </label>
-                                    @endif
-                                    @if ($item->delivery_available)
-                                    <label class="flex items-center p-3 border rounded-md has-[:checked]:bg-blue-50 has-[:checked]:border-blue-300 cursor-pointer">
-                                        <input type="radio" name="delivery_method_choice" value="delivery" x-model="deliveryMethod" class="h-4 w-4 text-blue-600 border-gray-300 focus:ring-blue-500" dusk="delivery-method-delivery">
-                                        <span class="ml-3 text-sm font-medium text-gray-700">Livraison</span>
-                                    </label>
-                                    @endif
+                        @auth
+                            @if(Auth::id() !== $item->user_id)
+                                <div class="mt-4 p-4 border rounded-md bg-gray-50" x-show="true">
+                                    <h3 class="font-semibold text-gray-800 mb-2">Veuillez sélectionner un mode de livraison pour acheter :</h3>
+                                    <div class="space-y-2">
+                                        @if ($item->pickup_available)
+                                        <label class="flex items-center p-3 border rounded-md has-[:checked]:bg-blue-50 has-[:checked]:border-blue-300 cursor-pointer">
+                                            <input type="radio" name="delivery_method_choice" value="pickup" x-model="deliveryMethod" class="h-4 w-4 text-blue-600 border-gray-300 focus:ring-blue-500" dusk="delivery-method-pickup">
+                                            <span class="ml-3 text-sm font-medium text-gray-700">Retrait sur place</span>
+                                        </label>
+                                        @endif
+                                        @if ($item->delivery_available)
+                                        <label class="flex items-center p-3 border rounded-md has-[:checked]:bg-blue-50 has-[:checked]:border-blue-300 cursor-pointer">
+                                            <input type="radio" name="delivery_method_choice" value="delivery" x-model="deliveryMethod" class="h-4 w-4 text-blue-600 border-gray-300 focus:ring-blue-500" dusk="delivery-method-delivery">
+                                            <span class="ml-3 text-sm font-medium text-gray-700">Livraison</span>
+                                        </label>
+                                        @endif
+                                    </div>
                                 </div>
+                            @endif
+                        @endauth
+                    </div>
+
+                    {{-- Section pour faire une offre --}}
+                    @auth
+                        @if(Auth::id() !== $item->user_id)
+                            <div class="mt-8 pt-8 border-t">
+                                <h2 class="text-2xl font-bold mb-4">Faire une offre</h2>
+                                <form action="{{ route('offers.store', $item) }}" method="POST">
+                                    @csrf
+                                    <input type="hidden" name="delivery_method" x-model="deliveryMethod">
+                                    <div class="flex items-center">
+                                        <input type="number" name="amount" id="amount" class="w-full px-4 py-2 border rounded-l-md" placeholder="Votre offre" required min="0.01" step="0.01">
+                                        <button type="submit" class="bg-green-500 hover:bg-green-700 text-white font-bold py-2 px-6 rounded-r-md" dusk="submit-offer-button">
+                                            Envoyer l'offre
+                                        </button>
+                                    </div>
+                                    @error('amount')
+                                        <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
+                                    @enderror
+                                </form>
                             </div>
                         @endif
                     @endauth
+                @else
+                    <div class="flex items-center justify-between mt-6">
+                        <span class="font-bold text-3xl">{{ number_format($item->price, 2, ',', ' ') }} €</span>
+                        <span class="bg-red-100 text-red-800 text-lg font-semibold mr-2 px-4 py-2 rounded-full">Article Vendu</span>
+                    </div>
+                @endif
                 </div>
-
-                {{-- Section pour faire une offre --}}
-                @auth
-                    @if(Auth::id() !== $item->user_id)
-                        <div class="mt-8 pt-8 border-t">
-                            <h2 class="text-2xl font-bold mb-4">Faire une offre</h2>
-                            <form action="{{ route('offers.store', $item) }}" method="POST">
-                                @csrf
-                                <input type="hidden" name="delivery_method" x-model="deliveryMethod">
-                                <div class="flex items-center">
-                                    <input type="number" name="amount" id="amount" class="w-full px-4 py-2 border rounded-l-md" placeholder="Votre offre" required min="0.01" step="0.01">
-                                    <button type="submit" class="bg-green-500 hover:bg-green-700 text-white font-bold py-2 px-6 rounded-r-md" dusk="submit-offer-button">
-                                        Envoyer l'offre
-                                    </button>
-                                </div>
-                                @error('amount')
-                                    <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-                                @enderror
-                            </form>
-                        </div>
-                    @endif
-                @endauth
-
             </div>
         </div>
     </div>

--- a/pifpaf/tests/Feature/ItemSoldPageTest.php
+++ b/pifpaf/tests/Feature/ItemSoldPageTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\Item;
+use App\Enums\ItemStatus;
+use App\Models\ItemImage;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+class ItemSoldPageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function sold_item_page_displays_sold_banner_and_hides_actions(): void
+    {
+        // Arrange: Create a user and a sold item with a primary image
+        $user = User::factory()->create();
+        $item = Item::factory()->create(['status' => ItemStatus::SOLD, 'user_id' => $user->id]);
+        ItemImage::factory()->create(['item_id' => $item->id, 'is_primary' => true]);
+        $viewer = User::factory()->create();
+
+        // Act: View the item page as another user
+        $response = $this->actingAs($viewer)->get(route('items.show', $item));
+
+        // Assert: Check for "VENDU" banner and absence of action buttons
+        $response->assertStatus(200);
+        $response->assertSee('VENDU');
+        $response->assertDontSee('Acheter');
+        $response->assertDontSee('Contacter le vendeur');
+        // Check that the offer button is not present using a direct PHPUnit regex assertion on the response content
+        $this->assertDoesNotMatchRegularExpression('/<button[^>]*dusk="submit-offer-button"[^>]*>/', $response->getContent());
+    }
+
+    #[Test]
+    public function available_item_page_displays_actions_and_no_banner(): void
+    {
+        // Arrange: Create a user and an available item with a primary image and delivery options
+        $user = User::factory()->create();
+        $item = Item::factory()->create([
+            'status' => ItemStatus::AVAILABLE,
+            'user_id' => $user->id,
+            'pickup_available' => true,
+            'delivery_available' => true
+        ]);
+        ItemImage::factory()->create(['item_id' => $item->id, 'is_primary' => true]);
+        $viewer = User::factory()->create();
+
+        // Act: View the item page as another user
+        $response = $this->actingAs($viewer)->get(route('items.show', $item));
+
+        // Assert: Check for the absence of "VENDU" banner and presence of action buttons
+        $response->assertStatus(200);
+        $response->assertDontSee('VENDU');
+        $response->assertSee('Acheter');
+        $response->assertSee('Contacter le vendeur');
+        // Use a direct PHPUnit regex assertion on the response content for robustness
+        $this->assertMatchesRegularExpression('/<button[^>]*dusk="submit-offer-button"[^>]*>[\s\r\n]*Envoyer l\'offre[\s\r\n]*<\/button>/', $response->getContent());
+    }
+}


### PR DESCRIPTION
Implements US-ANN-7 by updating the item detail view (`items.show.blade.php`).

When an item has a 'sold' status, the view now displays a large "VENDU" overlay on the primary image. All transactional user actions (e.g., "Acheter", "Contacter le vendeur", "Faire une offre") are hidden to prevent interactions with an unavailable item.

Adds `ItemSoldPageTest.php` to verify:
- The "VENDU" banner is present for sold items.
- Action buttons are hidden for sold items.
- The page renders correctly with action buttons and no banner for available items.