### PR TITLE
Fix(shipping): Prevent crash on shipment creation without address

### DIFF
--- a/pifpaf/app/Http/Controllers/TransactionController.php
+++ b/pifpaf/app/Http/Controllers/TransactionController.php
@@ -115,6 +115,10 @@ class TransactionController extends Controller
     {
         $this->authorize('update', $transaction->offer->item);
 
+        if (!$transaction->shippingAddress) {
+            return redirect()->back()->with('error', 'Cette transaction ne nécessite pas d\'expédition car elle n\'a pas d\'adresse de livraison.');
+        }
+
         // For now, we'll use a hardcoded shipping method ID.
         // In a real application, this would come from the user's choice.
         $shippingMethodId = 8; // Unstamped letter (for testing)


### PR DESCRIPTION
Resolves an "Attempt to read property 'name' on null" error that occurred in `SendcloudService` when trying to create a shipment for a transaction that did not have an associated shipping address.

Added a guard clause in `TransactionController@createShipment` to verify the presence of a shipping address before calling the service. If the address is missing, the user is redirected back with an appropriate error message.

Also added a feature test to ensure this validation works correctly and prevents the external API call.