### PR TITLE
Corrige le bug d'autorisation 403 lors de l'édition d'une adresse.

### DIFF
--- a/pifpaf/app/Http/Controllers/PickupAddressController.php
+++ b/pifpaf/app/Http/Controllers/PickupAddressController.php
@@ -61,7 +61,7 @@ class PickupAddressController extends Controller
     /**
      * Display the specified resource.
      */
-    public function show(PickupAddress $pickupAddress)
+    public function show(PickupAddress $address)
     {
         //
     }
@@ -69,18 +69,18 @@ class PickupAddressController extends Controller
     /**
      * Show the form for editing the specified resource.
      */
-    public function edit(PickupAddress $pickupAddress)
+    public function edit(PickupAddress $address)
     {
-        $this->authorize('update', $pickupAddress);
-        return view('profile.addresses.edit', ['address' => $pickupAddress]);
+        $this->authorize('update', $address);
+        return view('profile.addresses.edit', ['address' => $address]);
     }
 
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, PickupAddress $pickupAddress)
+    public function update(Request $request, PickupAddress $address)
     {
-        $this->authorize('update', $pickupAddress);
+        $this->authorize('update', $address);
 
         $validatedData = $request->validate([
             'name' => 'required|string|max:255',
@@ -102,12 +102,12 @@ class PickupAddressController extends Controller
         } else {
             // En cas d'échec du géocodage, on ne met pas à jour les coordonnées
             // pour ne pas écraser d'anciennes valeurs correctes.
-            $validatedData['latitude'] = $pickupAddress->latitude;
-            $validatedData['longitude'] = $pickupAddress->longitude;
+            $validatedData['latitude'] = $address->latitude;
+            $validatedData['longitude'] = $address->longitude;
         }
 
 
-        $pickupAddress->update($validatedData);
+        $address->update($validatedData);
 
         return redirect()->route('profile.addresses.index')->with('success', 'Adresse mise à jour avec succès.');
     }


### PR DESCRIPTION
Ce commit résout un bug qui empêchait les utilisateurs d'accéder à la page de modification de leurs propres adresses, retournant une erreur 403 Forbidden.

La cause racine était une non-correspondance dans le Route Model Binding de Laravel. Le paramètre de la route ressource était ` {address}`, mais la variable dans le `PickupAddressController` était typée en tant que `$pickupAddress`. Cette incohérence empêchait Laravel d'injecter correctement le modèle depuis la base de données. À la place, un modèle vide était injecté, ce qui provoquait l'échec de la vérification de la policy d'autorisation.

Le correctif consiste à renommer la variable dans les méthodes du contrôleur de `$pickupAddress` à `$address` pour qu'elle corresponde au nom du paramètre de la route, assurant ainsi que le Route Model Binding fonctionne comme prévu.