### PR TITLE
Refactor(dashboard): Use components for received offers

### DIFF
--- a/pifpaf/resources/views/components/dashboard/received-offer-list.blade.php
+++ b/pifpaf/resources/views/components/dashboard/received-offer-list.blade.php
@@ -1,0 +1,36 @@
+@props(['item'])
+
+@php
+    $pendingOffers = $item->offers->where('status', 'pending');
+@endphp
+
+<div class="p-4 border-t bg-gray-50">
+    <x-ui.section-title class="text-sm font-semibold text-gray-700">Offres reçues :</x-ui.section-title>
+
+    @if ($pendingOffers->isNotEmpty())
+        <ul class="mt-2 space-y-2">
+            @foreach ($pendingOffers as $offer)
+                <li>
+                    <x-ui.offer-card :offer="$offer" viewpoint="seller">
+                        <x-slot name="actions">
+                            <div class="flex space-x-1">
+                                <form action="{{ route('offers.accept', $offer) }}" method="POST">
+                                    @csrf
+                                    @method('PATCH')
+                                    <button type="submit" class="bg-green-500 text-white px-2 py-1 text-xs rounded hover:bg-green-600">Accepter</button>
+                                </form>
+                                <form action="{{ route('offers.reject', $offer) }}" method="POST">
+                                    @csrf
+                                    @method('PATCH')
+                                    <button type="submit" class="bg-red-500 text-white px-2 py-1 text-xs rounded hover:bg-red-600">Refuser</button>
+                                </form>
+                            </div>
+                        </x-slot>
+                    </x-ui.offer-card>
+                </li>
+            @endforeach
+        </ul>
+    @else
+        <x-ui.empty-state message="Aucune nouvelle offre pour cet article." />
+    @endif
+</div>

--- a/pifpaf/resources/views/components/ui/offer-card.blade.php
+++ b/pifpaf/resources/views/components/ui/offer-card.blade.php
@@ -21,6 +21,14 @@
              <p class="text-sm mt-1">
                 {{ $isSellerView ? 'Montant de l\'offre' : 'Votre offre' }}:
                 <span class="font-bold">{{ number_format($offer->amount, 2, ',', ' ') }} €</span>
+                 -
+                <span class="text-xs">
+                    @if ($offer->delivery_method === 'delivery')
+                        Livraison
+                    @elseif ($offer->delivery_method === 'pickup')
+                        Retrait sur place
+                    @endif
+                </span>
             </p>
         </div>
     </div>

--- a/pifpaf/resources/views/components/ui/section-title.blade.php
+++ b/pifpaf/resources/views/components/ui/section-title.blade.php
@@ -1,0 +1,10 @@
+@props(['level' => 2, 'class' => ''])
+
+@php
+$tag = 'h' . $level;
+$defaultClasses = 'text-2xl font-bold mb-6 text-center sm:text-left';
+@endphp
+
+<{{ $tag }} {{ $attributes->merge(['class' => $defaultClasses . ' ' . $class]) }}>
+    {{ $slot }}
+</{{ $tag }}>

--- a/pifpaf/resources/views/dashboard.blade.php
+++ b/pifpaf/resources/views/dashboard.blade.php
@@ -99,42 +99,11 @@
                                                 </div>
                                             </td>
                                         </tr>
-                                         {{-- Section des offres pour cet item --}}
+                                         {{-- Section des offres pour cet item (Desktop) --}}
                                         @if($item->status === \App\Enums\ItemStatus::AVAILABLE && $item->offers->where('status', 'pending')->isNotEmpty())
                                             <tr>
-                                                <td colspan="4" class="px-6 py-4 bg-gray-50">
-                                                    <div class="pl-10">
-                                                        <h5 class="text-sm font-semibold text-gray-700">Offres reçues :</h5>
-                                                        <ul class="mt-2 space-y-2">
-                                                            @foreach ($item->offers->where('status', 'pending') as $offer)
-                                                                <li class="p-2 border-b last:border-b-0">
-                                                                    <div class="flex items-center justify-between text-sm mb-1">
-                                                                        <span>
-                                                                            Acheteur : <a href="{{ route('profile.show', $offer->user) }}" class="text-blue-600 hover:underline">{{ $offer->user->name }}</a> - <span class="font-bold">{{ number_format($offer->amount, 2, ',', ' ') }} €</span>
-                                                                             -
-                                                                            @if ($offer->delivery_method === 'delivery')
-                                                                                <span>Livraison</span>
-                                                                            @elseif ($offer->delivery_method === 'pickup')
-                                                                                <span>Retrait sur place</span>
-                                                                            @endif
-                                                                        </span>
-                                                                        <div class="flex space-x-1">
-                                                                            <form action="{{ route('offers.accept', $offer) }}" method="POST">
-                                                                                @csrf
-                                                                                @method('PATCH')
-                                                                                <button type="submit" class="bg-green-500 text-white px-2 py-1 text-xs rounded hover:bg-green-600">Accepter</button>
-                                                                            </form>
-                                                                            <form action="{{ route('offers.reject', $offer) }}" method="POST">
-                                                                                @csrf
-                                                                                @method('PATCH')
-                                                                                <button type="submit" class="bg-red-500 text-white px-2 py-1 text-xs rounded hover:bg-red-600">Refuser</button>
-                                                                            </form>
-                                                                        </div>
-                                                                    </div>
-                                                                </li>
-                                                            @endforeach
-                                                        </ul>
-                                                    </div>
+                                                <td colspan="4" class="p-0">
+                                                    <x-dashboard.received-offer-list :item="$item" />
                                                 </td>
                                             </tr>
                                         @endif
@@ -193,40 +162,9 @@
                                                 <button type="submit" class="text-sm bg-red-500 text-white px-3 py-1 rounded hover:bg-red-600">Supprimer</button>
                                             </form>
                                         </div>
-                                    {{-- Section des offres pour cet item --}}
+                                     {{-- Section des offres pour cet item (Mobile) --}}
                                     @if($item->status === \App\Enums\ItemStatus::AVAILABLE && $item->offers->where('status', 'pending')->isNotEmpty())
-                                        <div class="p-4 border-t bg-gray-50">
-                                            <h5 class="font-semibold text-gray-700 text-sm">Offres reçues :</h5>
-                                            <ul class="mt-2 space-y-2">
-                                                @foreach ($item->offers->where('status', 'pending') as $offer)
-                                                    <li class="p-2 border-b last:border-b-0">
-                                                        <div class="flex items-center justify-between text-sm mb-1">
-                                                            <span>
-                                                                <a href="{{ route('profile.show', $offer->user) }}" class="text-blue-600 hover:underline">{{ $offer->user->name }}</a> - <span class="font-bold">{{ number_format($offer->amount, 2, ',', ' ') }} €</span>
-                                                                 -
-                                                                @if ($offer->delivery_method === 'delivery')
-                                                                    <span>Livraison</span>
-                                                                @elseif ($offer->delivery_method === 'pickup')
-                                                                    <span>Retrait sur place</span>
-                                                                @endif
-                                                            </span>
-                                                            <div class="flex space-x-1">
-                                                                <form action="{{ route('offers.accept', $offer) }}" method="POST">
-                                                                    @csrf
-                                                                    @method('PATCH')
-                                                                    <button type="submit" class="bg-green-500 text-white px-2 py-1 text-xs rounded hover:bg-green-600">Accepter</button>
-                                                                </form>
-                                                                <form action="{{ route('offers.reject', $offer) }}" method="POST">
-                                                                    @csrf
-                                                                    @method('PATCH')
-                                                                    <button type="submit" class="bg-red-500 text-white px-2 py-1 text-xs rounded hover:bg-red-600">Refuser</button>
-                                                                </form>
-                                                            </div>
-                                                        </div>
-                                                    </li>
-                                                @endforeach
-                                            </ul>
-                                        </div>
+                                       <x-dashboard.received-offer-list :item="$item" />
                                     @endif
                                 </div>
                             @endforeach


### PR DESCRIPTION
- Creates a new `dashboard.received-offer-list` Blade component to encapsulate the logic for displaying offers received for a specific item.
- Creates a new generic `ui.section-title` Blade component for consistent section headings.
- Updates the existing `ui.offer-card` component to display the delivery method, fixing a regression discovered during testing.
- Refactors the `dashboard.blade.php` view to use the new `received-offer-list` component.
- This change removes significant code duplication between the mobile and desktop views and improves the overall maintainability of the dashboard by adhering to a component-based architecture.