### PR TITLE
feat: Add Purchase Card Component

### DIFF
--- a/pifpaf/app/Http/Controllers/StyleguideController.php
+++ b/pifpaf/app/Http/Controllers/StyleguideController.php
@@ -169,6 +169,25 @@ class StyleguideController extends Controller
         );
         $saleShipped->load('offer.item.primaryImage', 'offer.user');
 
+        // --- Purchase Card Setup ---
+        // 1. Purchase waiting for reception confirmation
+        $purchaseWaitingForReception = clone $saleReadyForShipment;
+        $purchaseWaitingForReception->status = 'payment_received';
+        $purchaseWaitingForReception->load('offer.item.primaryImage', 'offer.item.user');
+
+
+        // 2. Purchase completed, no review left
+        $purchaseCompleted = clone $saleShipped;
+        $purchaseCompleted->status = 'completed';
+        $purchaseCompleted->setRelation('review', null); // Ensure no review is associated for the button to show
+        $purchaseCompleted->load('offer.item.primaryImage', 'offer.item.user');
+
+
+        // 3. Purchase with a shipping label
+        $purchaseWithLabel = clone $saleShipped;
+        $purchaseWithLabel->status = 'shipping_initiated';
+        $purchaseWithLabel->load('offer.item.primaryImage', 'offer.item.user');
+
 
         return view('styleguide', [
             'itemWithImage' => $itemWithImage,
@@ -182,6 +201,9 @@ class StyleguideController extends Controller
             'walletWithdrawal' => $walletWithdrawal,
             'saleReadyForShipment' => $saleReadyForShipment,
             'saleShipped' => $saleShipped,
+            'purchaseWaitingForReception' => $purchaseWaitingForReception,
+            'purchaseCompleted' => $purchaseCompleted,
+            'purchaseWithLabel' => $purchaseWithLabel,
         ]);
     }
 }

--- a/pifpaf/resources/views/components/purchase-card.blade.php
+++ b/pifpaf/resources/views/components/purchase-card.blade.php
@@ -1,0 +1,68 @@
+@props(['transaction'])
+
+<div class="bg-white rounded-lg shadow-md overflow-hidden mb-4 flex flex-col sm:flex-row">
+    <!-- Image -->
+    <a href="{{ route('items.show', $transaction->offer->item) }}" class="sm:w-32 md:w-48 flex-shrink-0">
+        @if ($transaction->offer->item->primaryImage)
+            <img class="w-full h-32 sm:h-full object-cover" src="{{ asset('storage/' . $transaction->offer->item->primaryImage->path) }}" alt="{{ $transaction->offer->item->title }}">
+        @else
+            <div class="w-full h-32 sm:h-full bg-gray-200 flex items-center justify-center">
+                <span class="text-gray-500 text-xs text-center">Aucune image</span>
+            </div>
+        @endif
+    </a>
+
+    <!-- Details -->
+    <div class="p-4 flex flex-col flex-grow">
+        <div>
+            <h3 class="font-bold text-lg">
+                <a href="{{ route('items.show', $transaction->offer->item) }}" class="hover:underline">{{ $transaction->offer->item->title }}</a>
+            </h3>
+            <p class="text-sm text-gray-600">
+                Vendu par : <a href="{{ route('profile.show', $transaction->offer->item->user) }}" class="text-blue-500 hover:underline">{{ $transaction->offer->item->user->name }}</a>
+            </p>
+        </div>
+
+        <div class="mt-2 flex-grow">
+            <div class="flex items-center justify-between text-sm text-gray-800">
+                <span>Prix payé</span>
+                <span class="font-semibold">{{ number_format($transaction->amount, 2, ',', ' ') }} €</span>
+            </div>
+            <div class="flex items-center justify-between text-sm text-gray-800 mt-1">
+                <span>Date de l'achat</span>
+                <span>{{ $transaction->created_at->format('d/m/Y') }}</span>
+            </div>
+            <div class="flex items-center justify-between text-sm text-gray-800 mt-1">
+                <span>Statut</span>
+                <span class="font-semibold px-2 py-1 bg-gray-200 text-gray-800 rounded-full text-xs">{{ $transaction->status }}</span>
+            </div>
+        </div>
+
+        <!-- Actions -->
+        <div class="mt-4 pt-4 border-t border-gray-200 flex flex-wrap items-center justify-end gap-2">
+            <a href="#" class="text-sm text-blue-500 hover:underline">Contacter le vendeur</a>
+
+            @if ($transaction->label_url)
+                <a href="{{ $transaction->label_url }}" target="_blank" class="px-3 py-1 bg-gray-200 text-gray-800 rounded-md text-sm hover:bg-gray-300">
+                    Voir l'étiquette
+                </a>
+            @endif
+
+            @if ($transaction->status === 'payment_received')
+                <form action="{{ route('transactions.confirm-reception', $transaction) }}" method="POST">
+                    @csrf
+                    @method('PATCH')
+                    <button type="submit" class="px-3 py-1 bg-green-500 text-white rounded-md text-sm hover:bg-green-600">
+                        Confirmer la réception
+                    </button>
+                </form>
+            @endif
+
+            @if ($transaction->status === 'completed' && !$transaction->review)
+                <a href="{{ route('reviews.store', $transaction) }}" class="px-3 py-1 bg-blue-500 text-white rounded-md text-sm hover:bg-blue-600">
+                    Laisser un avis
+                </a>
+            @endif
+        </div>
+    </div>
+</div>

--- a/pifpaf/resources/views/styleguide.blade.php
+++ b/pifpaf/resources/views/styleguide.blade.php
@@ -180,6 +180,29 @@
                 </div>
             </div>
 
+            <!-- Purchase Card -->
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 bg-white border-b border-gray-200">
+                    <h3 class="font-semibold text-xl text-gray-800 leading-tight mb-4">Purchase Card Component</h3>
+                    <p class="mb-4 text-gray-600">Displays a user's purchased item, including status and relevant actions.</p>
+
+                    <div class="space-y-6">
+                        <div>
+                            <h4 class="font-semibold text-lg text-gray-700 mb-2">State: Waiting for Reception Confirmation</h4>
+                            <x-purchase-card :transaction="$purchaseWaitingForReception" />
+                        </div>
+                        <div>
+                            <h4 class="font-semibold text-lg text-gray-700 mb-2">State: Completed, Awaiting Review</h4>
+                            <x-purchase-card :transaction="$purchaseCompleted" />
+                        </div>
+                        <div>
+                            <h4 class="font-semibold text-lg text-gray-700 mb-2">State: Shipped (with label)</h4>
+                            <x-purchase-card :transaction="$purchaseWithLabel" />
+                        </div>
+                    </div>
+                </div>
+            </div>
+
         </div>
     </div>
 </x-app-layout>

--- a/pifpaf/resources/views/transactions/purchases.blade.php
+++ b/pifpaf/resources/views/transactions/purchases.blade.php
@@ -8,29 +8,18 @@
     <div class="py-12">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
             <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
-                <div class="p-6 bg-white border-b border-gray-200">
+                <div class="p-6 bg-white border-b border-gray-200 space-y-4">
                     @forelse ($purchases as $transaction)
-                        <a href="{{ route('items.show', $transaction->offer->item) }}" class="flex items-center mb-4 border-b pb-4">
-                            @if ($transaction->offer->item->primaryImage && $transaction->offer->item->primaryImage->path)
-                                <img src="{{ asset('storage/' . $transaction->offer->item->primaryImage->path) }}" alt="{{ $transaction->offer->item->title }}" class="w-16 h-16 object-cover rounded">
-                            @else
-                                <div class="w-16 h-16 bg-gray-200 flex items-center justify-center rounded">
-                                    <span class="text-gray-500 text-xs text-center">Aucune image</span>
-                                </div>
-                            @endif
-                            <div class="ml-4">
-                                <div class="font-bold">{{ $transaction->offer->item->title }}</div>
-                                <div>Vendu par : <a href="{{ route('profile.show', $transaction->offer->item->user) }}" class="text-blue-500 hover:underline">{{ $transaction->offer->item->user->name }}</a></div>
-                                <div>{{ $transaction->amount }} €</div>
-                                <div>{{ $transaction->created_at->format('d/m/Y') }}</div>
-                                <div>Statut : {{ $transaction->status }}</div>
-                            </div>
-                        </a>
+                        <x-purchase-card :transaction="$transaction" />
                     @empty
                         <p>Vous n'avez effectué aucun achat pour le moment.</p>
                     @endforelse
 
-                    {{ $purchases->links() }}
+                    @if ($purchases->hasPages())
+                        <div class="mt-4">
+                            {{ $purchases->links() }}
+                        </div>
+                    @endif
                 </div>
             </div>
         </div>


### PR DESCRIPTION
- Creates a new reusable Blade component `x-purchase-card` to display purchase details and actions for the buyer.
- Adds conditional logic within the component to show relevant actions like "Confirm Reception", "Leave Review", and "View Label" based on the transaction status.
- Refactors the `transactions/purchases.blade.php` view to use the new component, significantly improving code clarity and maintainability.
- Adds the new component to the `/styleguide` with various states (payment received, completed, shipped) for easy visual validation and future development.
- Updates `StyleguideController` to provide the necessary mock `Transaction` objects for the component examples.