### PR TITLE
Désactive les tests de paiement pour éviter les transactions parasites

### DIFF
--- a/pifpaf/tests/Browser/PaymentFlowTest.php
+++ b/pifpaf/tests/Browser/PaymentFlowTest.php
@@ -17,6 +17,7 @@ class PaymentFlowTest extends DuskTestCase
     #[Test]
     public function an_buyer_can_see_and_pay_for_an_accepted_offer()
     {
+        $this->markTestSkipped('Les tests de paiement sont désactivés pour éviter les transactions parasites.');
         $seller = User::factory()->create();
         $buyer = User::factory()->create();
         $item = Item::factory()->create(['user_id' => $seller->id]);

--- a/pifpaf/tests/Browser/PaymentTest.php
+++ b/pifpaf/tests/Browser/PaymentTest.php
@@ -18,6 +18,7 @@ class PaymentTest extends DuskTestCase
     #[Test]
     public function a_user_can_pay_partially_with_wallet()
     {
+        $this->markTestSkipped('Les tests de paiement sont désactivés pour éviter les transactions parasites.');
         $seller = User::factory()->create();
         $buyer = User::factory()->create(['wallet' => 5.00]);
         $item = Item::factory()->create(['user_id' => $seller->id, 'price' => 20.00]);
@@ -55,6 +56,7 @@ class PaymentTest extends DuskTestCase
     #[Test]
     public function a_user_can_pay_fully_with_wallet()
     {
+        $this->markTestSkipped('Les tests de paiement sont désactivés pour éviter les transactions parasites.');
         $seller = User::factory()->create();
         $buyer = User::factory()->create(['wallet' => 20.00]);
         $item = Item::factory()->create(['user_id' => $seller->id, 'price' => 20.00]);
@@ -89,6 +91,7 @@ class PaymentTest extends DuskTestCase
     #[Test]
     public function a_user_can_pay_without_wallet()
     {
+        $this->markTestSkipped('Les tests de paiement sont désactivés pour éviter les transactions parasites.');
         $seller = User::factory()->create();
         $buyer = User::factory()->create(['wallet' => 5.00]);
         $item = Item::factory()->create(['user_id' => $seller->id, 'price' => 20.00]);

--- a/pifpaf/tests/Feature/Feature/PaymentFlowTest.php
+++ b/pifpaf/tests/Feature/Feature/PaymentFlowTest.php
@@ -16,6 +16,7 @@ class PaymentFlowTest extends TestCase
     #[Test]
     public function payment_creates_transaction_with_payment_received_status_and_does_not_pay_seller(): void
     {
+        $this->markTestSkipped('Les tests de paiement sont désactivés pour éviter les transactions parasites.');
         // 1. Arrange
         $seller = User::factory()->create(['wallet' => 0]);
         $buyer = User::factory()->create();

--- a/pifpaf/tests/Feature/PaymentTest.php
+++ b/pifpaf/tests/Feature/PaymentTest.php
@@ -16,6 +16,7 @@ class PaymentTest extends TestCase
     #[Test]
     public function an_authenticated_user_can_pay_for_an_accepted_offer(): void
     {
+        $this->markTestSkipped('Les tests de paiement sont désactivés pour éviter les transactions parasites.');
         // 1. Arrange
         $seller = User::factory()->create();
         $buyer = User::factory()->create();


### PR DESCRIPTION
Conformément à la demande, tous les tests de feature et de browser liés au flux de paiement ont été désactivés en utilisant `markTestSkipped`.

Cela empêchera la génération de transactions inutiles sur l'API de paiement lors des exécutions de la suite de tests automatisée. Les tests peuvent être facilement réactivés en supprimant l'appel à `markTestSkipped` à l'avenir.