### PR TITLE
feat: Display final selling price for sold items

### DIFF
--- a/pifpaf/app/Http/Controllers/ItemController.php
+++ b/pifpaf/app/Http/Controllers/ItemController.php
@@ -394,6 +394,7 @@ class ItemController extends Controller
      */
     public function show(Item $item)
     {
+        $item->load('offers.transaction');
         return view('items.show', [
             'item' => $item,
         ]);

--- a/pifpaf/resources/views/items/show.blade.php
+++ b/pifpaf/resources/views/items/show.blade.php
@@ -161,8 +161,24 @@
                         @endif
                     @endauth
                 @else
+                    @php
+                        $soldTransaction = null;
+                        foreach ($item->offers as $offer) {
+                            if ($offer->transaction && $offer->status === 'paid' && $offer->transaction->status === 'completed') {
+                                $soldTransaction = $offer->transaction;
+                                break;
+                            }
+                        }
+                    @endphp
                     <div class="flex items-center justify-between mt-6">
-                        <span class="font-bold text-3xl">{{ number_format($item->price, 2, ',', ' ') }} €</span>
+                        <span class="font-bold text-3xl">
+                            @if ($soldTransaction)
+                                {{ number_format($soldTransaction->amount, 2, ',', ' ') }} €
+                            @else
+                                {{-- Fallback au cas où la transaction n'est pas trouvée --}}
+                                {{ number_format($item->price, 2, ',', ' ') }} €
+                            @endif
+                        </span>
                         <span class="bg-red-100 text-red-800 text-lg font-semibold mr-2 px-4 py-2 rounded-full">Article Vendu</span>
                     </div>
                 @endif


### PR DESCRIPTION
This commit addresses issue #100.

When an item is sold, the item detail page now displays the final transaction amount instead of the original listing price.

- Eager-loaded the 'offers.transaction' relationship in the ItemController to efficiently fetch sales data.
- Updated the items.show view to find the completed transaction and display its amount.