### PR TITLE
feat(logistics): Add tracking number functionality for sellers

### DIFF
--- a/pifpaf/app/Http/Controllers/TransactionController.php
+++ b/pifpaf/app/Http/Controllers/TransactionController.php
@@ -143,4 +143,30 @@ class TransactionController extends Controller
 
         return redirect()->route('dashboard')->with('error', 'Erreur lors de la création de l\'envoi.');
     }
+
+    /**
+     * Ajoute un numéro de suivi à une transaction.
+     *
+     * @param \Illuminate\Http\Request $request
+     * @param \App\Models\Transaction $transaction
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function addTracking(Request $request, Transaction $transaction)
+    {
+        // On s'assure que l'utilisateur connecté est bien le vendeur de l'article concerné
+        $this->authorize('update', $transaction->offer->item);
+
+        // Valider la requête
+        $request->validate([
+            'tracking_code' => 'required|string|max:255',
+        ]);
+
+        // Mettre à jour la transaction avec le numéro de suivi et le nouveau statut
+        $transaction->update([
+            'tracking_code' => $request->tracking_code,
+            'status' => 'in_transit',
+        ]);
+
+        return redirect()->route('transactions.sales')->with('success', 'Numéro de suivi ajouté avec succès.');
+    }
 }

--- a/pifpaf/resources/views/components/sales/card.blade.php
+++ b/pifpaf/resources/views/components/sales/card.blade.php
@@ -50,7 +50,25 @@
                 </a>
             @endif
 
-            {{-- Placeholder for future actions --}}
+            {{-- Formulaire pour ajouter un numéro de suivi --}}
+            @if ($transaction->status === 'shipping_initiated' && !$transaction->tracking_code)
+                <form action="{{ route('transactions.addTracking', $transaction) }}" method="POST" class="flex items-center space-x-2">
+                    @csrf
+                    @method('PATCH')
+                    <input type="text" name="tracking_code" placeholder="Numéro de suivi" class="w-full px-3 py-2 text-sm border-gray-300 rounded-lg focus:ring-indigo-500 focus:border-indigo-500">
+                    <button type="submit" class="px-4 py-2 text-sm font-medium text-white bg-indigo-600 rounded-lg hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+                        Ajouter
+                    </button>
+                </form>
+            @endif
+
+            {{-- Affichage du numéro de suivi --}}
+            @if ($transaction->tracking_code)
+                <div class="text-sm text-gray-600">
+                    <span class="font-semibold">N° de suivi :</span> {{ $transaction->tracking_code }}
+                </div>
+            @endif
+
              <a href="#" class="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
                 Contacter l'acheteur
             </a>

--- a/pifpaf/routes/web.php
+++ b/pifpaf/routes/web.php
@@ -49,6 +49,7 @@ Route::middleware('auth')->group(function () {
     Route::post('/payment/{offer}', [PaymentController::class, 'store'])->name('payment.store');
     Route::patch('/transactions/{transaction}/confirm-pickup', [TransactionController::class, 'confirmPickup'])->name('transactions.confirm-pickup');
     Route::patch('/transactions/{transaction}/confirm-reception', [TransactionController::class, 'confirmReception'])->name('transactions.confirm-reception');
+    Route::patch('/transactions/{transaction}/add-tracking', [TransactionController::class, 'addTracking'])->name('transactions.addTracking');
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');

--- a/pifpaf/tests/Feature/AddTrackingNumberTest.php
+++ b/pifpaf/tests/Feature/AddTrackingNumberTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Item;
+use App\Models\Offer;
+use App\Models\Transaction;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AddTrackingNumberTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function a_seller_can_add_a_tracking_number_to_a_transaction()
+    {
+        $seller = User::factory()->create();
+        $buyer = User::factory()->create();
+        $item = Item::factory()->create(['user_id' => $seller->id]);
+        $offer = Offer::factory()->create(['item_id' => $item->id, 'user_id' => $buyer->id]);
+        $transaction = Transaction::factory()->create(['offer_id' => $offer->id, 'status' => 'shipping_initiated']);
+
+        $trackingNumber = '123456789';
+
+        $response = $this->actingAs($seller)
+            ->patch(route('transactions.addTracking', $transaction), [
+                'tracking_code' => $trackingNumber,
+            ]);
+
+        $response->assertRedirect(route('transactions.sales'));
+        $response->assertSessionHas('success', 'Numéro de suivi ajouté avec succès.');
+
+        $this->assertDatabaseHas('transactions', [
+            'id' => $transaction->id,
+            'tracking_code' => $trackingNumber,
+            'status' => 'in_transit',
+        ]);
+    }
+
+    /** @test */
+    public function an_unauthorized_user_cannot_add_a_tracking_number()
+    {
+        $seller = User::factory()->create();
+        $buyer = User::factory()->create();
+        $unauthorizedUser = User::factory()->create();
+        $item = Item::factory()->create(['user_id' => $seller->id]);
+        $offer = Offer::factory()->create(['item_id' => $item->id, 'user_id' => $buyer->id]);
+        $transaction = Transaction::factory()->create(['offer_id' => $offer->id, 'status' => 'shipping_initiated']);
+
+        $trackingNumber = '123456789';
+
+        $response = $this->actingAs($unauthorizedUser)
+            ->patch(route('transactions.addTracking', $transaction), [
+                'tracking_code' => $trackingNumber,
+            ]);
+
+        $response->assertStatus(403);
+
+        $this->assertDatabaseHas('transactions', [
+            'id' => $transaction->id,
+            'tracking_code' => null,
+            'status' => 'shipping_initiated',
+        ]);
+    }
+
+    /** @test */
+    public function a_tracking_number_is_required()
+    {
+        $seller = User::factory()->create();
+        $buyer = User::factory()->create();
+        $item = Item::factory()->create(['user_id' => $seller->id]);
+        $offer = Offer::factory()->create(['item_id' => $item->id, 'user_id' => $buyer->id]);
+        $transaction = Transaction::factory()->create(['offer_id' => $offer->id, 'status' => 'shipping_initiated']);
+
+        $response = $this->actingAs($seller)
+            ->patch(route('transactions.addTracking', $transaction), [
+                'tracking_code' => '',
+            ]);
+
+        $response->assertSessionHasErrors('tracking_code');
+
+        $this->assertDatabaseHas('transactions', [
+            'id' => $transaction->id,
+            'tracking_code' => null,
+            'status' => 'shipping_initiated',
+        ]);
+    }
+}


### PR DESCRIPTION
This commit introduces the ability for a seller to add a tracking number to a shipped order.

- Adds a PATCH route `transactions/{transaction}/add-tracking`.
- Implements the `addTracking` method in `TransactionController` to handle the logic, including validation and authorization.
- Updates the sales view (`components/sales/card.blade.php`) to conditionally display a form for submitting the tracking number.
- Adds a new feature test (`AddTrackingNumberTest.php`) to ensure the functionality is robust and secure.