### PR TITLE
Fix(ci): Correct working directory and PHP version in GitHub Actions

### DIFF
--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -14,21 +14,27 @@ jobs:
     steps:
     - uses: shivammathur/setup-php@15c43e89cdef867065b0213be354c2841860869e
       with:
-        php-version: '8.0'
+        php-version: '8.3'
     - uses: actions/checkout@v4
     - name: Copy .env
+      working-directory: pifpaf
       run: php -r "file_exists('.env') || copy('.env.example', '.env');"
     - name: Install Dependencies
+      working-directory: pifpaf
       run: composer install -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
     - name: Generate key
+      working-directory: pifpaf
       run: php artisan key:generate
     - name: Directory Permissions
+      working-directory: pifpaf
       run: chmod -R 777 storage bootstrap/cache
     - name: Create Database
+      working-directory: pifpaf
       run: |
         mkdir -p database
         touch database/database.sqlite
     - name: Execute tests (Unit and Feature tests) via PHPUnit/Pest
+      working-directory: pifpaf
       env:
         DB_CONNECTION: sqlite
         DB_DATABASE: database/database.sqlite


### PR DESCRIPTION
The laravel-tests workflow was failing during the 'Install Dependencies' step. This was due to two issues:

1. The commands were executed at the repository root, but the Laravel project resides in the 'pifpaf/' subdirectory.
2. The workflow was using PHP 8.0, while the project requires PHP ^8.2.

This commit resolves these issues by setting the `working-directory` to `pifpaf` for all relevant steps and updating the `php-version` to `8.3`.