### PR TITLE
Fix: Corrige l'erreur fatale sur le tableau de bord et optimise les r…

### DIFF
--- a/pifpaf/app/Http/Controllers/StyleguideController.php
+++ b/pifpaf/app/Http/Controllers/StyleguideController.php
@@ -179,7 +179,7 @@ class StyleguideController extends Controller
         // 2. Purchase completed, no review left
         $purchaseCompleted = clone $saleShipped;
         $purchaseCompleted->status = 'completed';
-        $purchaseCompleted->setRelation('review', null); // Ensure no review is associated for the button to show
+        $purchaseCompleted->setRelation('reviews', collect()); // Ensure no review is associated for the button to show
         $purchaseCompleted->load('offer.item.primaryImage', 'offer.item.user');
 
 

--- a/pifpaf/app/Http/Controllers/TransactionController.php
+++ b/pifpaf/app/Http/Controllers/TransactionController.php
@@ -85,7 +85,7 @@ class TransactionController extends Controller
     {
         $purchases = Transaction::whereHas('offer', function ($query) {
             $query->where('user_id', Auth::id());
-        })->with('offer.item.primaryImage', 'offer.item.user')->latest()->paginate(10);
+        })->with(['offer.item.primaryImage', 'offer.item.user', 'reviews'])->latest()->paginate(10);
 
         return view('transactions.purchases', compact('purchases'));
     }
@@ -114,7 +114,7 @@ class TransactionController extends Controller
     {
         $this->authorize('view', $transaction);
 
-        $transaction->load('offer.item.user', 'offer.user', 'review', 'shippingAddress');
+        $transaction->load('offer.item.user', 'offer.user', 'reviews', 'shippingAddress');
 
         return view('transactions.show', compact('transaction'));
     }

--- a/pifpaf/app/Models/Transaction.php
+++ b/pifpaf/app/Models/Transaction.php
@@ -32,8 +32,8 @@ class Transaction extends Model
         return $this->belongsTo(ShippingAddress::class);
     }
 
-    public function review()
+    public function reviews()
     {
-        return $this->hasOne(Review::class);
+        return $this->hasMany(Review::class);
     }
 }

--- a/pifpaf/resources/views/components/purchase-card.blade.php
+++ b/pifpaf/resources/views/components/purchase-card.blade.php
@@ -59,10 +59,8 @@
                 </form>
             @endif
 
-            @if ($transaction->status === 'completed' && !$transaction->review)
-                <a href="{{ route('reviews.store', $transaction) }}" class="px-3 py-1 bg-blue-500 text-white rounded-md text-sm hover:bg-blue-600">
-                    Laisser un avis
-                </a>
+            @if ($transaction->status === 'completed' && !$transaction->reviews->contains('reviewer_id', Auth::id()))
+                <x-review-modal :transaction="$transaction" :recipientName="$transaction->offer->item->user->name" />
             @endif
         </div>
     </div>


### PR DESCRIPTION
…equêtes.

Cette modification corrige une `BadMethodCallException` qui se produisait sur la page du tableau de bord. L'erreur était due à un appel à une relation `reviews()` inexistante sur le modèle `Transaction`.

La solution consiste à :
1.  Renommer la relation `review()` en `reviews()` dans le modèle `Transaction` et la passer en `hasMany`.
2.  Mettre à jour toutes les parties du code qui utilisaient l'ancienne relation au singulier.
3.  Optimiser les requêtes sur la page des achats (`purchases`) en chargeant en amont (eager loading) la relation `reviews` pour corriger un problème de performance N+1 qui avait été introduit.