### PR TITLE
Fix: Assure une hauteur uniforme pour les fiches articles

### DIFF
--- a/pifpaf/resources/views/components/ui/item-card.blade.php
+++ b/pifpaf/resources/views/components/ui/item-card.blade.php
@@ -1,6 +1,6 @@
 @props(['item'])
 
-<div class="group relative rounded-lg overflow-hidden shadow-lg hover:shadow-2xl transition-shadow duration-300 ease-in-out">
+<div class="group relative rounded-lg overflow-hidden shadow-lg hover:shadow-2xl transition-shadow duration-300 ease-in-out flex flex-col">
     <a href="{{ route('items.show', $item) }}" class="absolute inset-0 z-10">
         <span class="sr-only">Voir l'article {{ $item->title }}</span>
     </a>
@@ -9,18 +9,20 @@
         <x-ui.item-thumbnail :item="$item" class="w-full h-full object-cover" />
     </div>
 
-    <div class="p-4 bg-white">
-        <h3 class="font-bold text-lg truncate text-gray-800" title="{{ $item->title }}">
-            <a href="{{ route('items.show', $item) }}" class="hover:underline">
-                {{ $item->title }}
-            </a>
-        </h3>
+    <div class="p-4 bg-white flex flex-col flex-grow">
+        <div>
+            <h3 class="font-bold text-lg truncate text-gray-800" title="{{ $item->title }}">
+                <a href="{{ route('items.show', $item) }}" class="hover:underline">
+                    {{ $item->title }}
+                </a>
+            </h3>
 
-        <div class="mt-2">
-             <x-ui.user-profile-link :user="$item->user" />
+            <div class="mt-2">
+                <x-ui.user-profile-link :user="$item->user" />
+            </div>
         </div>
 
-        <div class="flex justify-between items-center mt-3">
+        <div class="flex justify-between items-center mt-auto pt-3">
             <p class="text-xl font-semibold text-gray-900">{{ number_format($item->price, 2, ',', ' ') }} €</p>
 
             <div class="text-sm text-gray-600">


### PR DESCRIPTION
Ce commit corrige un problème d'affichage sur les grilles d'articles où les fiches (`item-card`) avaient des hauteurs différentes en fonction de la longueur de leur contenu.

La solution a été implémentée en modifiant le composant Blade `resources/views/components/ui/item-card.blade.php`.

- Le conteneur principal de la carte a été transformé en conteneur flex vertical (`flex flex-col`).
- La zone de contenu a été configurée pour occuper tout l'espace vertical disponible (`flex-grow`).
- Le pied de page de la carte (prix et informations de livraison) est désormais aligné en bas grâce à `mt-auto`.

Cette modification garantit que toutes les cartes d'une même rangée ont la même hauteur, créant ainsi une grille visuellement cohérente et professionnelle.

Fixes #139