### PR TITLE
fix(tests): correct assertions in PickupAddressManagementTest

### DIFF
--- a/pifpaf/tests/Browser/PickupAddressManagementTest.php
+++ b/pifpaf/tests/Browser/PickupAddressManagementTest.php
@@ -40,7 +40,7 @@ class PickupAddressManagementTest extends DuskTestCase
                     ->waitForText('Mes Adresses')
                     ->clickLink('Mes Adresses')
                     ->assertPathIs('/profile/addresses')
-                    ->assertSee('Mes Adresses de Retrait');
+                    ->assertSee('Mes Adresses');
         });
     }
 
@@ -51,7 +51,7 @@ class PickupAddressManagementTest extends DuskTestCase
         $this->browse(function (Browser $browser) use ($user) {
             $browser->loginAs($user)
                 ->visit('/profile/addresses')
-                ->clickLink('Ajouter une nouvelle adresse')
+                ->clickLink('Ajouter une adresse de retrait')
                 ->assertPathIs('/profile/addresses/create')
                 ->type('name', 'Maison')
                 ->type('street', '123 rue de Paris')


### PR DESCRIPTION
The Dusk test for pickup address management was failing due to outdated text assertions.

- Updated `assertSee('Mes Adresses de Retrait')` to `assertSee('Mes Adresses')` to match the page header.
- Updated `clickLink('Ajouter une nouvelle adresse')` to `clickLink('Ajouter une adresse de retrait')` to match the button text.

This ensures the test accurately reflects the current state of the UI and passes reliably.