### PR TITLE
docs: Reinforce agent operational directive

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# Directive Fondamentale pour l'Agent IA (Jules)
+
+## Règle Impérative et Non-Négociable
+
+Pour toute tâche de développement, de correction de bug, ou toute autre opération sur ce projet, **il est impératif et obligatoire de suivre scrupuleusement la procédure définie dans le document suivant :**
+
+[**`doc/agent_mission_template.md`**](./doc/agent_mission_template.md)
+
+Cette procédure constitue la première étape de toute action. Ne commencez aucune analyse ou modification du code avant d'avoir lu, compris et planifié votre travail conformément à ce document.
+
+Le non-respect de cette directive est considéré comme une faute critique.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Pifpaf - Marketplace de Seconde Main Assistée par IA
 
+> [!IMPORTANT]
+> **Directive pour l'Agent IA (Jules)**
+> Toute intervention sur ce projet doit **impérativement** suivre la procédure définie dans le fichier `AGENTS.md`. C'est une règle non-négociable.
+> **[Consulter la directive](./AGENTS.md)**
+
 ## 1. Vue d'ensemble du Projet
 
 Pifpaf est un Proof of Concept (PoC) pour une marketplace de seconde main qui se distingue par une intégration poussée de l'Intelligence Artificielle (IA) via **Gemini 2.5 Flash**. L'objectif est de simplifier radicalement l'expérience de mise en vente en automatisant la création d'annonces à partir d'une simple photo.


### PR DESCRIPTION
Creates an AGENTS.md file with the imperative instruction to follow the procedure in doc/agent_mission_template.md.

Adds a prominent notice to the main README.md, linking to AGENTS.md to ensure this directive is the first thing the agent sees.

This change aims to ensure the agent consistently follows the established development procedure without needing to be reminded in every task.