### PR TITLE
Chore: Skip failing payment test

### DIFF
--- a/doc/known_issues.md
+++ b/doc/known_issues.md
@@ -52,12 +52,12 @@ L'objectif est de fournir une vue d'ensemble claire de l'état de la base de cod
   - **Raison :** "Skipping AI validation test."
   - **Fichier :** `pifpaf/tests/Browser/ValidateAiSuggestionsTest.php`
 
+- **Test:** `Tests\Browser\BuyerConfirmsReceptionTest`
+  - **Raison :** "Les tests de paiement sont désactivés car ils dépendent de services externes non disponibles dans l'environnement de test Dusk."
+  - **Fichier :** `pifpaf/tests/Browser/BuyerConfirmsReceptionTest.php`
+
 
 ### Tests Défaillants (Failures)
-
-- **Test:** `Tests\Browser\BuyerConfirmsReceptionTest` > `buyer can pay and then confirm reception`
-  - **Erreur :** `Did not see expected text [Article à Payer et Confirmer] within element [body].` Le test n'a pas trouvé le texte attendu sur le tableau de bord de l'acheteur.
-  - **Fichier :** `pifpaf/tests/Browser/BuyerConfirmsReceptionTest.php`
 
 - **Test:** `Tests\Browser\PickupAddressManagementTest` > `user can navigate to addresses page`
   - **Erreur :** `Did not see expected text [Mes Adresses de Retrait] within element [body].` Le test n'a pas trouvé le titre attendu sur la page de gestion des adresses.


### PR DESCRIPTION
The `Tests\Browser\BuyerConfirmsReceptionTest` is consistently failing due to its dependency on the Stripe API, which is unavailable in the Dusk testing environment.

As per the user's request, this test is now marked as skipped to prevent blocking the CI/CD pipeline. The underlying issue with testing external services in Dusk will be addressed separately.

The test's status has been updated in `doc/known_issues.md`.