### PR TITLE
feat: Modernize item card aspect ratio handling

### DIFF
--- a/pifpaf/resources/views/components/ui/item-card.blade.php
+++ b/pifpaf/resources/views/components/ui/item-card.blade.php
@@ -5,7 +5,7 @@
         <span class="sr-only">Voir l'article {{ $item->title }}</span>
     </a>
 
-    <div class="aspect-w-1 aspect-h-1 w-full overflow-hidden">
+    <div class="aspect-square w-full overflow-hidden">
         <x-ui.item-thumbnail :item="$item" class="w-full h-full object-cover" />
     </div>
 


### PR DESCRIPTION
Replaced the deprecated Tailwind CSS `aspect-w-1 aspect-h-1` classes with the modern `aspect-square` utility in the `item-card` component.

This ensures that item card images maintain a consistent 1:1 aspect ratio, gracefully handling images of various original dimensions by cropping them to fit without distortion (`object-cover`). This resolves layout inconsistencies in the item grid.