### PR TITLE
Fix(ci): build frontend assets before running tests

### DIFF
--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -25,6 +25,16 @@ jobs:
     - name: Generate key
       working-directory: pifpaf
       run: php artisan key:generate
+    - name: Setup Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+    - name: Install NPM dependencies
+      working-directory: pifpaf
+      run: npm install
+    - name: Build assets
+      working-directory: pifpaf
+      run: npm run build
     - name: Directory Permissions
       working-directory: pifpaf
       run: chmod -R 777 storage bootstrap/cache


### PR DESCRIPTION
The GitHub Actions workflow was failing because the Vite manifest was not found during the execution of PHPUnit tests. This occurred because the frontend assets were not being compiled.

This commit adds the necessary steps to the `laravel.yml` workflow to:
1. Set up Node.js
2. Install NPM dependencies (`npm install`)
3. Build the assets (`npm run build`)

These steps are executed before the `php artisan test` command, ensuring that the Vite manifest and compiled assets are available, which resolves the CI error.