### PR TITLE
Refactor: Extrait la liste des articles dans un composant Blade

### DIFF
--- a/pifpaf/app/Http/Controllers/ItemController.php
+++ b/pifpaf/app/Http/Controllers/ItemController.php
@@ -80,7 +80,7 @@ class ItemController extends Controller
             }
         }
 
-        $items = $query->get();
+        $items = $query->paginate(12);
 
         return view('welcome', [
             'items' => $items,

--- a/pifpaf/app/Http/Controllers/ProfileController.php
+++ b/pifpaf/app/Http/Controllers/ProfileController.php
@@ -12,11 +12,12 @@ class ProfileController extends Controller
      */
     public function show(User $user)
     {
-        $user->load('items', 'reviewsReceived.reviewer');
+        $user->load('reviewsReceived.reviewer');
+        $items = $user->items()->available()->with('primaryImage')->latest()->paginate(9);
 
         $averageRating = $user->reviewsReceived->avg('rating');
         $reviewCount = $user->reviewsReceived->count();
 
-        return view('profile.show', compact('user', 'averageRating', 'reviewCount'));
+        return view('profile.show', compact('user', 'items', 'averageRating', 'reviewCount'));
     }
 }

--- a/pifpaf/resources/views/components/item-list.blade.php
+++ b/pifpaf/resources/views/components/item-list.blade.php
@@ -1,0 +1,17 @@
+@props(['items'])
+
+<div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-8">
+    @forelse ($items as $item)
+        <x-ui.item-card :item="$item" />
+    @empty
+        <div class="col-span-full text-center text-gray-500">
+            <p>Aucun article trouvé.</p>
+        </div>
+    @endforelse
+</div>
+
+@if ($items->hasPages())
+    <div class="mt-8">
+        {{ $items->links() }}
+    </div>
+@endif

--- a/pifpaf/resources/views/profile/show.blade.php
+++ b/pifpaf/resources/views/profile/show.blade.php
@@ -34,15 +34,7 @@
 
             <div class="mt-8 pt-8 border-t">
                 <h2 class="text-2xl font-bold mb-4">Articles en vente</h2>
-                @if($user->items->count() > 0)
-                    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mt-4">
-                        @foreach($user->items as $item)
-                            <x-ui.item-card :item="$item" />
-                        @endforeach
-                    </div>
-                @else
-                    <p class="mt-4">Cet utilisateur n'a aucun article en vente pour le moment.</p>
-                @endif
+                <x-item-list :items="$items" />
             </div>
         </div>
     </div>

--- a/pifpaf/resources/views/welcome.blade.php
+++ b/pifpaf/resources/views/welcome.blade.php
@@ -49,14 +49,6 @@
             </div>
         </div>
 
-        <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-8">
-            @forelse ($items as $item)
-                <x-ui.item-card :item="$item" />
-            @empty
-                <div class="col-span-full text-center text-gray-500">
-                    <p>Aucun article trouvé. Essayez d'ajuster vos filtres de recherche.</p>
-                </div>
-            @endforelse
-        </div>
+        <x-item-list :items="$items" />
     </div>
 </x-main-layout>

--- a/pifpaf/tests/Feature/Feature/ProfileTest.php
+++ b/pifpaf/tests/Feature/Feature/ProfileTest.php
@@ -60,9 +60,7 @@ class ProfileTest extends TestCase
 
         // Assert that the "no items" message is visible by checking the raw content
         $this->assertTrue(
-            str_contains($response->getContent(), 'Cet utilisateur n\'a aucun article en vente pour le moment.') ||
-            str_contains($response->getContent(), 'Cet utilisateur n&apos;a aucun article en vente pour le moment.') ||
-            str_contains($response->getContent(), 'Cet utilisateur n&#039;a aucun article en vente pour le moment.')
+            str_contains($response->getContent(), 'Aucun article trouvé.')
         );
     }
 }

--- a/pifpaf/tests/Feature/ItemSearchTest.php
+++ b/pifpaf/tests/Feature/ItemSearchTest.php
@@ -113,7 +113,7 @@ class ItemSearchTest extends TestCase
 
         // Utilisation de str_contains pour contourner les problèmes d'encodage de l'assertion
         $this->assertTrue(
-            str_contains($response->getContent(), "Aucun article trouvé. Essayez d'ajuster vos filtres de recherche.")
+            str_contains($response->getContent(), "Aucun article trouvé.")
         );
     }
 }


### PR DESCRIPTION
Ce commit extrait la logique d'affichage de la liste des articles et de la pagination dans un composant Blade réutilisable `item-list`.

- Crée le composant `resources/views/components/item-list.blade.php`.
- Met à jour `ItemController` et `ProfileController` pour utiliser la pagination de Laravel.
- Intègre le nouveau composant dans les vues `welcome.blade.php` et `profile/show.blade.php`, simplifiant ainsi le code et améliorant la maintenabilité.
- Met à jour les tests Feature qui vérifiaient le message d'absence d'articles pour correspondre au nouveau message générique du composant.