### PR TITLE
refactor(tests): migrate deprecated @test annotations to #[Test] attr…

### DIFF
--- a/pifpaf/tests/Feature/AddTrackingNumberTest.php
+++ b/pifpaf/tests/Feature/AddTrackingNumberTest.php
@@ -7,13 +7,14 @@ use App\Models\Offer;
 use App\Models\Transaction;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 class AddTrackingNumberTest extends TestCase
 {
     use RefreshDatabase;
 
-    /** @test */
+    #[Test]
     public function a_seller_can_add_a_tracking_number_to_a_transaction()
     {
         $seller = User::factory()->create();
@@ -39,7 +40,7 @@ class AddTrackingNumberTest extends TestCase
         ]);
     }
 
-    /** @test */
+    #[Test]
     public function an_unauthorized_user_cannot_add_a_tracking_number()
     {
         $seller = User::factory()->create();
@@ -65,7 +66,7 @@ class AddTrackingNumberTest extends TestCase
         ]);
     }
 
-    /** @test */
+    #[Test]
     public function a_tracking_number_is_required()
     {
         $seller = User::factory()->create();

--- a/pifpaf/tests/Feature/Admin/UserManagementTest.php
+++ b/pifpaf/tests/Feature/Admin/UserManagementTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Admin;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 class UserManagementTest extends TestCase
@@ -20,7 +21,7 @@ class UserManagementTest extends TestCase
         $this->user = User::factory()->create(['role' => 'user']);
     }
 
-    /** @test */
+    #[Test]
     public function only_admins_can_access_the_user_management_page()
     {
         // Un non-administrateur reçoit une erreur 403
@@ -34,7 +35,7 @@ class UserManagementTest extends TestCase
              ->assertStatus(200);
     }
 
-    /** @test */
+    #[Test]
     public function user_list_is_displayed_correctly()
     {
         $this->actingAs($this->admin)
@@ -43,7 +44,7 @@ class UserManagementTest extends TestCase
              ->assertSee($this->user->email);
     }
 
-    /** @test */
+    #[Test]
     public function search_functionality_works()
     {
         $userToFind = User::factory()->create(['name' => 'John Doe Search']);
@@ -54,7 +55,7 @@ class UserManagementTest extends TestCase
              ->assertDontSee($this->user->name);
     }
 
-    /** @test */
+    #[Test]
     public function admin_can_ban_a_user()
     {
         $this->actingAs($this->admin)
@@ -63,7 +64,7 @@ class UserManagementTest extends TestCase
         $this->assertNotNull($this->user->fresh()->banned_at);
     }
 
-    /** @test */
+    #[Test]
     public function admin_can_unban_a_user()
     {
         $this->user->update(['banned_at' => now()]);
@@ -75,7 +76,7 @@ class UserManagementTest extends TestCase
         $this->assertNull($this->user->fresh()->banned_at);
     }
 
-    /** @test */
+    #[Test]
     public function a_banned_user_cannot_log_in()
     {
         // Bannir l'utilisateur
@@ -91,7 +92,7 @@ class UserManagementTest extends TestCase
         $this->assertGuest();
     }
 
-    /** @test */
+    #[Test]
     public function a_logged_in_user_is_logged_out_on_next_request_if_banned()
     {
         // Se connecter en tant qu'utilisateur normal

--- a/pifpaf/tests/Feature/AdminDashboardTest.php
+++ b/pifpaf/tests/Feature/AdminDashboardTest.php
@@ -7,20 +7,21 @@ use App\Models\Item;
 use App\Models\Offer;
 use App\Models\Transaction;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 class AdminDashboardTest extends TestCase
 {
     use RefreshDatabase;
 
-    /** @test */
+    #[Test]
     public function guests_are_redirected_from_admin_dashboard()
     {
         $this->get(route('admin.dashboard'))
             ->assertRedirect(route('login'));
     }
 
-    /** @test */
+    #[Test]
     public function non_admin_users_are_forbidden()
     {
         $user = User::factory()->create(['role' => 'user']);
@@ -30,7 +31,7 @@ class AdminDashboardTest extends TestCase
             ->assertForbidden();
     }
 
-    /** @test */
+    #[Test]
     public function admin_can_see_dashboard_with_stats()
     {
         // Arrange

--- a/pifpaf/tests/Feature/AdminItemsTest.php
+++ b/pifpaf/tests/Feature/AdminItemsTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use App\Models\Item;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 class AdminItemsTest extends TestCase
@@ -21,7 +22,7 @@ class AdminItemsTest extends TestCase
         $this->user = User::factory()->create(['role' => 'user']);
     }
 
-    /** @test */
+    #[Test]
     public function non_admins_cannot_access_the_admin_items_index()
     {
         $this->actingAs($this->user)
@@ -29,7 +30,7 @@ class AdminItemsTest extends TestCase
              ->assertStatus(403);
     }
 
-    /** @test */
+    #[Test]
     public function admin_can_access_the_admin_items_index()
     {
         $this->actingAs($this->admin)
@@ -38,7 +39,7 @@ class AdminItemsTest extends TestCase
              ->assertViewIs('admin.items.index');
     }
 
-    /** @test */
+    #[Test]
     public function admin_can_view_a_list_of_items()
     {
         $item1 = Item::factory()->create(['title' => 'Item Alpha']);
@@ -50,7 +51,7 @@ class AdminItemsTest extends TestCase
              ->assertSee('Item Beta');
     }
 
-    /** @test */
+    #[Test]
     public function admin_can_search_for_items_by_title()
     {
         Item::factory()->create(['title' => 'Specific Search Term']);
@@ -62,7 +63,7 @@ class AdminItemsTest extends TestCase
              ->assertDontSee('Another Item');
     }
 
-    /** @test */
+    #[Test]
     public function admin_can_search_for_items_by_seller_name()
     {
         $seller = User::factory()->create(['name' => 'John Doe']);
@@ -75,7 +76,7 @@ class AdminItemsTest extends TestCase
              ->assertDontSee('Anonymous Item');
     }
 
-    /** @test */
+    #[Test]
     public function admin_can_delete_an_item()
     {
         $item = Item::factory()->create();
@@ -86,7 +87,7 @@ class AdminItemsTest extends TestCase
         $this->assertDatabaseMissing('items', ['id' => $item->id]);
     }
 
-    /** @test */
+    #[Test]
     public function non_admins_cannot_delete_an_item()
     {
         $item = Item::factory()->create();

--- a/pifpaf/tests/Feature/ProfilePageTest.php
+++ b/pifpaf/tests/Feature/ProfilePageTest.php
@@ -9,12 +9,13 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 use App\Models\User;
 use App\Models\Review;
+use PHPUnit\Framework\Attributes\Test;
 
 class ProfilePageTest extends TestCase
 {
     use RefreshDatabase;
 
-    /** @test */
+    #[Test]
     public function it_displays_user_average_rating_and_reviews()
     {
         // 1. Arrange
@@ -67,7 +68,7 @@ class ProfilePageTest extends TestCase
         $response->assertSee('Transaction parfaite, je recommande.');
     }
 
-    /** @test */
+    #[Test]
     public function it_displays_a_message_when_there_are_no_reviews()
     {
         // 1. Arrange

--- a/pifpaf/tests/Feature/ReviewControllerTest.php
+++ b/pifpaf/tests/Feature/ReviewControllerTest.php
@@ -7,6 +7,7 @@ use App\Models\Offer;
 use App\Models\Transaction;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 class ReviewControllerTest extends TestCase
@@ -28,7 +29,7 @@ class ReviewControllerTest extends TestCase
         $this->transaction = Transaction::factory()->create(['offer_id' => $offer->id, 'status' => 'completed']);
     }
 
-    /** @test */
+    #[Test]
     public function buyer_can_leave_a_review_on_a_completed_transaction()
     {
         $this->actingAs($this->buyer);
@@ -46,7 +47,7 @@ class ReviewControllerTest extends TestCase
         ]);
     }
 
-    /** @test */
+    #[Test]
     public function seller_can_leave_a_review_on_a_completed_transaction()
     {
         $this->actingAs($this->seller);
@@ -64,7 +65,7 @@ class ReviewControllerTest extends TestCase
         ]);
     }
 
-    /** @test */
+    #[Test]
     public function user_cannot_leave_a_review_on_an_incomplete_transaction()
     {
         $this->transaction->update(['status' => 'payment_received']);
@@ -77,7 +78,7 @@ class ReviewControllerTest extends TestCase
         $this->assertDatabaseMissing('reviews', ['transaction_id' => $this->transaction->id]);
     }
 
-    /** @test */
+    #[Test]
     public function user_cannot_leave_a_review_on_a_transaction_they_are_not_part_of()
     {
         $unrelatedUser = User::factory()->create();
@@ -90,7 +91,7 @@ class ReviewControllerTest extends TestCase
         $this->assertDatabaseMissing('reviews', ['transaction_id' => $this->transaction->id]);
     }
 
-    /** @test */
+    #[Test]
     public function user_cannot_leave_two_reviews_for_the_same_transaction()
     {
         $this->actingAs($this->buyer);
@@ -104,7 +105,7 @@ class ReviewControllerTest extends TestCase
         $this->assertEquals(1, $this->transaction->reviews()->count());
     }
 
-    /** @test */
+    #[Test]
     public function rating_is_required_and_must_be_between_1_and_5()
     {
         $this->actingAs($this->buyer);


### PR DESCRIPTION
…ibutes

The GitHub Actions workflow was failing with an exit code 1, despite all tests passing. This was caused by PHPUnit 11 deprecation warnings for `@test` annotations being treated as errors in the CI environment.

This commit refactors the affected test files to use the modern `#[Test]` attribute syntax, which resolves the warnings and allows the CI pipeline to pass successfully.