### PR TITLE
Fix: Corrige l'assertion regex dans ItemSoldPageTest

### DIFF
--- a/pifpaf/tests/Feature/ItemSoldPageTest.php
+++ b/pifpaf/tests/Feature/ItemSoldPageTest.php
@@ -58,6 +58,6 @@ class ItemSoldPageTest extends TestCase
         $response->assertSee('Acheter');
         $response->assertSee('Contacter le vendeur');
         // Use a direct PHPUnit regex assertion on the response content for robustness
-        $this->assertMatchesRegularExpression('/<button[^>]*dusk="submit-offer-button"[^>]*>[\s\r\n]*Envoyer l\'offre[\s\r\n]*<\/button>/', $response->getContent());
+        $this->assertMatchesRegularExpression('/<button[^>]*dusk="submit-offer-button"[^>]*>[\s\r\n]*Envoyer l(&#039;|\')offre[\s\r\n]*<\/button>/', $response->getContent());
     }
 }


### PR DESCRIPTION
Le test échouait car l'apostrophe dans "l'offre" était encodée en HTML (&#039;), ce qui ne correspondait pas à l'expression régulière.

La regex a été mise à jour pour accepter à la fois l'apostrophe littéral et son entité HTML, rendant le test plus robuste.