### PR TITLE
feat: Add pagination to seller dashboard

### DIFF
--- a/pifpaf/app/Http/Controllers/ItemController.php
+++ b/pifpaf/app/Http/Controllers/ItemController.php
@@ -112,7 +112,7 @@ class ItemController extends Controller
                 }
             ])
             ->latest()
-            ->get();
+            ->paginate(10);
 
         // Récupérer les transactions ouvertes (achats et ventes)
         $openTransactions = \App\Models\Transaction::where(function ($query) use ($userId) {

--- a/pifpaf/resources/views/components/dashboard/annonces-list.blade.php
+++ b/pifpaf/resources/views/components/dashboard/annonces-list.blade.php
@@ -90,6 +90,10 @@
             @endforeach
         </tbody>
     </table>
+
+    <div class="mt-4">
+        {{ $items->links() }}
+    </div>
 </div>
 
 <!-- Vue Cartes pour Mobile -->
@@ -148,4 +152,8 @@
             @endif
         </div>
     @endforeach
+
+    <div class="mt-4">
+        {{ $items->links() }}
+    </div>
 </div>


### PR DESCRIPTION
Adds pagination to the seller's item list on the dashboard.

- Modifies `ItemController` to use `paginate()` instead of `get()`.
- Adds pagination links to the `annonces-list` Blade component.

Fixes #137