### PR TITLE
Fix: Répare les tests de paiement en simulant l'API Stripe

### DIFF
--- a/pifpaf/tests/Feature/Feature/PaymentFlowTest.php
+++ b/pifpaf/tests/Feature/Feature/PaymentFlowTest.php
@@ -8,15 +8,21 @@ use App\Models\Offer;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
+use Mockery;
 
 class PaymentFlowTest extends TestCase
 {
     use RefreshDatabase;
 
+    public function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
     #[Test]
     public function payment_creates_transaction_with_payment_received_status_and_does_not_pay_seller(): void
     {
-        $this->markTestSkipped('Les tests de paiement sont désactivés pour éviter les transactions parasites.');
         // 1. Arrange
         $seller = User::factory()->create(['wallet' => 0]);
         $buyer = User::factory()->create();
@@ -27,9 +33,18 @@ class PaymentFlowTest extends TestCase
             'status' => 'accepted',
         ]);
 
+        // Simuler l'API Stripe
+        Mockery::mock('overload:\Stripe\PaymentIntent')->shouldReceive('retrieve')->andReturn((object) [
+            'status' => 'succeeded',
+            'amount' => round($offer->amount * 100),
+        ]);
+
         // 2. Act
         $response = $this->actingAs($buyer)
-                         ->post(route('payment.store', $offer));
+                         ->post(route('payment.store', $offer), [
+                             'payment_intent_id' => 'pi_mock_id',
+                             'use_wallet' => false,
+                         ]);
 
         // 3. Assert
         $response->assertRedirect(route('dashboard'));

--- a/pifpaf/tests/Feature/PickupAvailableTest.php
+++ b/pifpaf/tests/Feature/PickupAvailableTest.php
@@ -11,6 +11,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\Http;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use Mockery;
@@ -59,7 +60,10 @@ class PickupAvailableTest extends TestCase
         $buyer = User::factory()->create();
         $item = Item::factory()->create(['user_id' => $seller->id, 'pickup_available' => true]);
         $offer = Offer::factory()->create(['user_id' => $buyer->id, 'item_id' => $item->id, 'status' => 'accepted', 'amount' => 10.00]);
-        Mockery::mock('alias:\Stripe\PaymentIntent')->shouldReceive('retrieve')->andReturn((object) ['status' => 'succeeded','amount' => $offer->amount * 100,]);
+        Mockery::mock('overload:\Stripe\PaymentIntent')->shouldReceive('retrieve')->andReturn((object) [
+            'status' => 'succeeded',
+            'amount' => round($offer->amount * 100),
+        ]);
 
         $this->actingAs($buyer);
 
@@ -82,7 +86,10 @@ class PickupAvailableTest extends TestCase
         $buyer = User::factory()->create();
         $item = Item::factory()->create(['user_id' => $seller->id, 'pickup_available' => false]);
         $offer = Offer::factory()->create(['user_id' => $buyer->id, 'item_id' => $item->id, 'status' => 'accepted', 'amount' => 10.00]);
-        Mockery::mock('alias:\Stripe\PaymentIntent')->shouldReceive('retrieve')->andReturn((object) ['status' => 'succeeded','amount' => $offer->amount * 100,]);
+        Mockery::mock('overload:\Stripe\PaymentIntent')->shouldReceive('retrieve')->andReturn((object) [
+            'status' => 'succeeded',
+            'amount' => round($offer->amount * 100),
+        ]);
 
         $this->actingAs($buyer);
 
@@ -105,7 +112,10 @@ class PickupAvailableTest extends TestCase
             'amount' => 10.00,
             'delivery_method' => 'pickup'
         ]);
-        Mockery::mock('alias:\Stripe\PaymentIntent')->shouldReceive('retrieve')->andReturn((object) ['status' => 'succeeded','amount' => $offer->amount * 100,]);
+        Mockery::mock('overload:\Stripe\PaymentIntent')->shouldReceive('retrieve')->andReturn((object) [
+            'status' => 'succeeded',
+            'amount' => round($offer->amount * 100),
+        ]);
         $this->actingAs($buyer)->post(route('payment.store', $offer), ['payment_intent_id' => 'pi_fake']);
         $transaction = $offer->refresh()->transaction;
 
@@ -122,7 +132,10 @@ class PickupAvailableTest extends TestCase
         $buyer = User::factory()->create();
         $item = Item::factory()->create(['user_id' => $seller->id, 'pickup_available' => true]);
         $offer = Offer::factory()->create(['user_id' => $buyer->id, 'item_id' => $item->id, 'status' => 'accepted', 'amount' => 10.00]);
-        Mockery::mock('alias:\Stripe\PaymentIntent')->shouldReceive('retrieve')->andReturn((object) ['status' => 'succeeded','amount' => $offer->amount * 100,]);
+        Mockery::mock('overload:\Stripe\PaymentIntent')->shouldReceive('retrieve')->andReturn((object) [
+            'status' => 'succeeded',
+            'amount' => round($offer->amount * 100),
+        ]);
 
         // Simuler le paiement
         $this->actingAs($buyer)->post(route('payment.store', $offer), ['payment_intent_id' => 'pi_fake']);
@@ -142,7 +155,10 @@ class PickupAvailableTest extends TestCase
         $buyer = User::factory()->create();
         $item = Item::factory()->create(['user_id' => $seller->id, 'pickup_available' => true]);
         $offer = Offer::factory()->create(['user_id' => $buyer->id, 'item_id' => $item->id, 'status' => 'accepted', 'amount' => 10.00]);
-        Mockery::mock('alias:\Stripe\PaymentIntent')->shouldReceive('retrieve')->andReturn((object) ['status' => 'succeeded','amount' => $offer->amount * 100,]);
+        Mockery::mock('overload:\Stripe\PaymentIntent')->shouldReceive('retrieve')->andReturn((object) [
+            'status' => 'succeeded',
+            'amount' => round($offer->amount * 100),
+        ]);
         $this->actingAs($buyer)->post(route('payment.store', $offer), ['payment_intent_id' => 'pi_fake']);
         $transaction = $offer->refresh()->transaction;
 
@@ -162,7 +178,10 @@ class PickupAvailableTest extends TestCase
         $buyer = User::factory()->create();
         $item = Item::factory()->create(['user_id' => $seller->id, 'pickup_available' => true]);
         $offer = Offer::factory()->create(['user_id' => $buyer->id, 'item_id' => $item->id, 'status' => 'accepted', 'amount' => 10.00]);
-        Mockery::mock('alias:\Stripe\PaymentIntent')->shouldReceive('retrieve')->andReturn((object) ['status' => 'succeeded','amount' => $offer->amount * 100,]);
+        Mockery::mock('overload:\Stripe\PaymentIntent')->shouldReceive('retrieve')->andReturn((object) [
+            'status' => 'succeeded',
+            'amount' => round($offer->amount * 100),
+        ]);
 
         // Simuler le paiement
         $this->actingAs($buyer)->post(route('payment.store', $offer), ['payment_intent_id' => 'pi_fake']);


### PR DESCRIPTION
Réactive et corrige les tests de paiement qui étaient précédemment désactivés.

- Utilise Mockery pour simuler les appels statiques à l'API Stripe, évitant ainsi les appels réseau réels et les "transactions parasites".
- Refactorise plusieurs tests (PaymentTest, PaymentFlowTest, PickupAvailableTest) pour utiliser une stratégie de simulation cohérente.
- Ajoute la méthode tearDown() avec Mockery::close() pour garantir un nettoyage correct des simulations entre les tests et éviter les conflits.

Cela résout le problème du code de sortie 1 de la suite de tests et garantit que le flux de paiement est correctement couvert par les tests automatisés.