### PR TITLE
feat(checkout): Add order summary page

### DIFF
--- a/pifpaf/app/Http/Controllers/CheckoutController.php
+++ b/pifpaf/app/Http/Controllers/CheckoutController.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Offer;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class CheckoutController extends Controller
+{
+    /**
+     * Display the order summary page.
+     *
+     * @param  \App\Models\Offer  $offer
+     * @return \Illuminate\View\View
+     */
+    public function summary(Offer $offer)
+    {
+        // Ensure the authenticated user is the buyer.
+        if (Auth::id() !== $offer->user_id) {
+            abort(403, 'Unauthorized access.');
+        }
+
+        // Ensure the offer has been accepted.
+        if ($offer->status !== 'accepted') {
+            return redirect()->route('dashboard')->withErrors(['error' => 'This offer is not ready for checkout.']);
+        }
+
+        return view('checkout.summary', compact('offer'));
+    }
+}

--- a/pifpaf/app/Http/Controllers/OfferController.php
+++ b/pifpaf/app/Http/Controllers/OfferController.php
@@ -67,7 +67,7 @@ class OfferController extends Controller
              ->where('status', 'pending')
              ->update(['status' => 'rejected']);
 
-        return redirect()->route('payment.create', $offer);
+        return redirect()->route('checkout.summary', $offer);
     }
 
     /**

--- a/pifpaf/resources/views/checkout/summary.blade.php
+++ b/pifpaf/resources/views/checkout/summary.blade.php
@@ -1,0 +1,77 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Récapitulatif de la commande') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 bg-white border-b border-gray-200">
+
+                    <h3 class="text-lg font-medium text-gray-900 mb-4">
+                        Veuillez vérifier les détails de votre commande avant de procéder au paiement.
+                    </h3>
+
+                    <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                        <!-- Colonne de gauche : Détails de l'article -->
+                        <div>
+                            <h4 class="font-semibold text-gray-800">Article</h4>
+                            <div class="mt-2 flex">
+                                <img src="{{ optional($offer->item->primaryImage)->image_path ? asset('storage/' . $offer->item->primaryImage->image_path) : asset('images/placeholder.jpg') }}" alt="{{ $offer->item->name }}" class="w-24 h-24 object-cover rounded-md">
+                                <div class="ml-4">
+                                    <p class="font-bold">{{ $offer->item->name }}</p>
+                                    <p class="text-sm text-gray-600">Vendu par : {{ $offer->item->user->name }}</p>
+                                    <p class="text-lg font-bold text-gray-800 mt-2">{{ number_format($offer->amount, 2, ',', ' ') }} €</p>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Colonne de droite : Détails de la livraison et financier -->
+                        <div>
+                            <h4 class="font-semibold text-gray-800">Livraison</h4>
+                            <div class="mt-2">
+                                @if($offer->delivery_method == 'pickup')
+                                    <p>Remise en main propre</p>
+                                    <p class="text-sm text-gray-600 mt-1">
+                                        Adresse du vendeur : {{ $offer->item->pickupAddress->street }}, {{ $offer->item->pickupAddress->city }}
+                                    </p>
+                                @else
+                                    <p>Livraison standard</p>
+                                    {{-- Ici, on affichera l'adresse de livraison de l'acheteur --}}
+                                    <p class="text-sm text-gray-600 mt-1">
+                                        Adresse de livraison : À implémenter (carnet d'adresses)
+                                    </p>
+                                @endif
+                            </div>
+
+                            <h4 class="font-semibold text-gray-800 mt-6">Récapitulatif financier</h4>
+                            <div class="mt-2 space-y-1">
+                                <div class="flex justify-between">
+                                    <span>Prix de l'article :</span>
+                                    <span>{{ number_format($offer->amount, 2, ',', ' ') }} €</span>
+                                </div>
+                                <div class="flex justify-between">
+                                    <span>Frais de livraison :</span>
+                                    <span>0,00 €</span> {{-- À ajuster si la livraison a un coût --}}
+                                </div>
+                                <div class="flex justify-between font-bold text-lg border-t pt-2 mt-2">
+                                    <span>Total à payer :</span>
+                                    <span>{{ number_format($offer->amount, 2, ',', ' ') }} €</span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Bouton d'action -->
+                    <div class="mt-8 text-right">
+                        <a href="{{ route('payment.create', $offer) }}" class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 active:bg-gray-900 focus:outline-none focus:border-gray-900 focus:ring ring-gray-300 disabled:opacity-25 transition ease-in-out duration-150">
+                            Procéder au paiement
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/pifpaf/routes/web.php
+++ b/pifpaf/routes/web.php
@@ -12,6 +12,7 @@ use App\Http\Controllers\WalletController;
 use App\Http\Controllers\ItemImageController;
 use App\Http\Controllers\PickupAddressController;
 use App\Http\Controllers\AiRequestController;
+use App\Http\Controllers\CheckoutController;
 use App\Http\Controllers\StyleguideController;
 
 Route::get('/', [ItemController::class, 'welcome'])->name('welcome');
@@ -45,6 +46,7 @@ Route::middleware('auth')->group(function () {
     Route::post('/items/{item}/buy-now', [OfferController::class, 'buyNow'])->name('offers.buyNow');
     Route::patch('/offers/{offer}/accept', [OfferController::class, 'accept'])->name('offers.accept');
     Route::patch('/offers/{offer}/reject', [OfferController::class, 'reject'])->name('offers.reject');
+    Route::get('/checkout/{offer}/summary', [CheckoutController::class, 'summary'])->name('checkout.summary');
     Route::get('/payment/{offer}', [PaymentController::class, 'create'])->name('payment.create');
     Route::post('/payment/{offer}', [PaymentController::class, 'store'])->name('payment.store');
     Route::patch('/transactions/{transaction}/confirm-pickup', [TransactionController::class, 'confirmPickup'])->name('transactions.confirm-pickup');

--- a/pifpaf/tests/Feature/CheckoutFlowTest.php
+++ b/pifpaf/tests/Feature/CheckoutFlowTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Item;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CheckoutFlowTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Test that a user is redirected to the order summary page after a buy now action.
+     *
+     * @return void
+     */
+    public function test_buy_now_redirects_to_summary_page()
+    {
+        // Arrange
+        $seller = User::factory()->create();
+        $buyer = User::factory()->create();
+        $item = Item::factory()->create(['user_id' => $seller->id, 'price' => 100]);
+
+        // Act
+        $response = $this->actingAs($buyer)->post(route('offers.buyNow', $item), [
+            'delivery_method' => 'pickup'
+        ]);
+
+        // Assert
+        $response->assertStatus(302);
+        $response->assertRedirectContains('/checkout/');
+        $response->assertRedirectContains('/summary');
+    }
+}


### PR DESCRIPTION
Implements the order summary page as the first step in the checkout flow, as per US-CHK-1.

- Creates a new `CheckoutController` and `checkout.summary` route.
- Adds a `summary.blade.php` view to display order details.
- Updates the `buyNow` action in `OfferController` to redirect to the new summary page.
- Includes a feature test to verify the new flow.

This provides a better user experience by allowing buyers to review their order before payment.