### PR TITLE
🛡️ Sentinel: [HIGH] Fix mass assignment vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-16 - [Fix Mass Assignment Vulnerability in BankAccountController]
+**Vulnerability:** A mass assignment vulnerability existed in `BankAccountController.php` because `store()` and `update()` methods used `$request->all()` while the `user_id` attribute was listed in the model's `$fillable` array. This could potentially allow users to manipulate the `user_id` during creation or updates.
+**Learning:** Even if `create()` is chained to a relationship like `Auth::user()->bankAccounts()->create($request->all())`, using `$request->all()` remains risky because it includes all payload data, not just the data intentionally allowed by validation logic.
+**Prevention:** Always use the validated data array returned by `$request->validate()` (e.g. `$validated = $request->validate(...)`) instead of `$request->all()` when creating or updating models, particularly when foreign keys are mass-assignable.

--- a/pifpaf/app/Http/Controllers/BankAccountController.php
+++ b/pifpaf/app/Http/Controllers/BankAccountController.php
@@ -32,13 +32,13 @@ class BankAccountController extends Controller
      */
     public function store(Request $request)
     {
-        $request->validate([
+        $validated = $request->validate([
             'account_holder_name' => 'required|string|max:255',
             'iban' => 'required|string|max:34', // Assuming IBAN max length
             'bic' => 'required|string|max:11', // Assuming BIC max length
         ]);
 
-        Auth::user()->bankAccounts()->create($request->all());
+        Auth::user()->bankAccounts()->create($validated);
 
         return redirect()->route('profile.bank-accounts.index')->with('success', 'Compte bancaire ajouté avec succès.');
     }
@@ -68,13 +68,13 @@ class BankAccountController extends Controller
     {
         $this->authorize('update', $bankAccount);
 
-        $request->validate([
+        $validated = $request->validate([
             'account_holder_name' => 'required|string|max:255',
             'iban' => 'required|string|max:34',
             'bic' => 'required|string|max:11',
         ]);
 
-        $bankAccount->update($request->all());
+        $bankAccount->update($validated);
 
         return redirect()->route('profile.bank-accounts.index')->with('success', 'Compte bancaire mis à jour avec succès.');
     }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: A mass assignment vulnerability existed in `BankAccountController.php` because `store()` and `update()` methods used `$request->all()` while the `user_id` attribute was listed in the model's `$fillable` array.
🎯 Impact: This could potentially allow users to manipulate the `user_id` during creation or updates, assigning a bank account to another user.
🔧 Fix: Used the `$validated` array returned by `$request->validate()` instead of `$request->all()` to ensure only allowed fields are saved.
✅ Verification: Ran unit tests for BankAccounts.

---
*PR created automatically by Jules for task [3235071217095192617](https://jules.google.com/task/3235071217095192617) started by @Ganngann*