### PR TITLE
🎨 Palette: [UX improvement] Add ARIA attributes to navigation

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-05-16 - Add ARIA Labels to Navigation Elements
+**Learning:** Icon-only links and toggle buttons (like the notifications bell and hamburger menu) are common in Laravel Breeze/Alpine navigation components but often lack accessible labels by default.
+**Action:** When adding or reviewing icon-only interactive elements, ensure `aria-label` is present. For elements that toggle state (like dropdowns or mobile menus), bind `aria-expanded` to the state variable (e.g., `:aria-expanded="open.toString()"` in Alpine.js) to communicate state to screen readers.

--- a/pifpaf/package-lock.json
+++ b/pifpaf/package-lock.json
@@ -2017,7 +2017,6 @@
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -2251,7 +2250,6 @@
             "integrity": "sha512-ZWyE8YXEXqJrrSLvYgrRP7p62OziLW7xI5HYGWFzOvupfAlrLvURSzv/FyGyy0eidogEM3ujU+kUG1zuHgb6Ug==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "esbuild": "^0.25.0",
                 "fdir": "^6.5.0",

--- a/pifpaf/resources/views/layouts/navigation.blade.php
+++ b/pifpaf/resources/views/layouts/navigation.blade.php
@@ -26,7 +26,7 @@
             <!-- Wallet Balance & Settings Dropdown -->
             <div class="hidden sm:flex sm:items-center sm:ml-6">
                 @auth
-                    <a href="{{ route('notifications.index') }}" class="relative mr-4 text-gray-500 hover:text-gray-700">
+                    <a href="{{ route('notifications.index') }}" aria-label="Notifications" class="relative mr-4 text-gray-500 hover:text-gray-700">
                         <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"></path>
                         </svg>
@@ -40,7 +40,7 @@
 
                     <!-- Settings Dropdown -->
                     <div class="relative z-50" x-data="{ open: false }">
-                        <button @click="open = ! open" dusk="nav-user-dropdown" class="flex items-center text-sm font-medium text-gray-500 hover:text-gray-700 hover:border-gray-300 focus:outline-none focus:text-gray-700 focus:border-gray-300 transition duration-150 ease-in-out">
+                        <button @click="open = ! open" dusk="nav-user-dropdown" :aria-expanded="open.toString()" class="flex items-center text-sm font-medium text-gray-500 hover:text-gray-700 hover:border-gray-300 focus:outline-none focus:text-gray-700 focus:border-gray-300 transition duration-150 ease-in-out">
                             <div>{{ Auth::user()->name }}</div>
 
                             <div class="ml-1">
@@ -122,7 +122,7 @@
 
             <!-- Hamburger -->
             <div class="-mr-2 flex items-center sm:hidden">
-                <button @click="open = ! open" dusk="hamburger-button" class="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:bg-gray-100 focus:text-gray-500 transition duration-150 ease-in-out">
+                <button @click="open = ! open" dusk="hamburger-button" aria-label="Toggle navigation menu" :aria-expanded="open.toString()" class="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:bg-gray-100 focus:text-gray-500 transition duration-150 ease-in-out">
                     <svg class="h-6 w-6" stroke="currentColor" fill="none" viewBox="0 0 24 24">
                         <path :class="{'hidden': open, 'inline-flex': ! open }" class="inline-flex" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
                         <path :class="{'hidden': ! open, 'inline-flex': open }" class="hidden" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />


### PR DESCRIPTION
🎨 Palette: Navigation Accessibility Improvements

💡 What: Added missing `aria-label` attributes to icon-only buttons (notifications and hamburger menu) and added `aria-expanded` attributes bound to the Alpine.js state for the dropdowns.
🎯 Why: To improve screen reader accessibility and navigation state communication, making the core navigation structure usable for all users.
♿ Accessibility: Ensures interactive icon-only elements have descriptive names and that collapsible sections communicate their current state (open/closed) to assistive technologies.

---
*PR created automatically by Jules for task [17493246631752278991](https://jules.google.com/task/17493246631752278991) started by @Ganngann*