### PR TITLE
⚡ Bolt: Replace unreadNotifications N+1 fetch with relationship count

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+## 2024-05-16 - [N+1 query in navigation]
+**Learning:** Checking `Auth::user()->unreadNotifications->count()` inside the navigation layout triggers an N+1 query issue since notifications might not be loaded, and `count()` triggers a separate count query on the relation each time it's called (or loads all notifications). Actually, it loads the relation because it uses the property `unreadNotifications` and then calls `count()` on the collection. In this case, `unreadNotifications()->count()` is much more efficient as it performs an aggregate query, but even better is doing it right in a View Composer if needed, or just `unreadNotifications()->count()`. Wait, since it's `Auth::user()->unreadNotifications->count()`, it loads ALL unread notifications into memory just to count them!
+
+**Action:** Replace `$user->unreadNotifications->count()` with `$user->unreadNotifications()->count()`. This executes a simple `COUNT(*)` query without fetching the actual model records.

--- a/pifpaf/package-lock.json
+++ b/pifpaf/package-lock.json
@@ -2017,7 +2017,6 @@
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -2251,7 +2250,6 @@
             "integrity": "sha512-ZWyE8YXEXqJrrSLvYgrRP7p62OziLW7xI5HYGWFzOvupfAlrLvURSzv/FyGyy0eidogEM3ujU+kUG1zuHgb6Ug==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "esbuild": "^0.25.0",
                 "fdir": "^6.5.0",

--- a/pifpaf/resources/views/layouts/navigation.blade.php
+++ b/pifpaf/resources/views/layouts/navigation.blade.php
@@ -30,8 +30,9 @@
                         <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"></path>
                         </svg>
-                        @if (Auth::user()->unreadNotifications->count() > 0)
-                            <span class="absolute top-0 right-0 inline-flex items-center justify-center px-2 py-1 text-xs font-bold leading-none text-red-100 bg-red-600 rounded-full transform translate-x-1/2 -translate-y-1/2">{{ Auth::user()->unreadNotifications->count() }}</span>
+                        @php $unreadCount = Auth::user()->unreadNotifications()->count(); @endphp
+                        @if ($unreadCount > 0)
+                            <span class="absolute top-0 right-0 inline-flex items-center justify-center px-2 py-1 text-xs font-bold leading-none text-red-100 bg-red-600 rounded-full transform translate-x-1/2 -translate-y-1/2">{{ $unreadCount }}</span>
                         @endif
                     </a>
                     <div class="mr-4 text-sm font-medium text-gray-500">


### PR DESCRIPTION
💡 What: Updated the check and display for unread notifications in the navigation layout to utilize an optimized aggregate COUNT query via `unreadNotifications()->count()` and assign it to a variable, rather than hydrating an entire collection.

🎯 Why: Preventing a classic N+1 database issue on every authenticated page load when retrieving unread notification counts. The previous logic used `unreadNotifications->count()`, resulting in loading and instantiating many Notification models into memory unnecessarily.

📊 Impact: Reduces memory load and database processing time per page request.

🔬 Measurement: You can verify using Laravel's Query Log, Clockwork or Telescope debugger showing that no notification models are retrieved.

---
*PR created automatically by Jules for task [17692771170034301951](https://jules.google.com/task/17692771170034301951) started by @Ganngann*