### PR TITLE
⚡ Bolt: Remove repeated count query in ItemController update loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -2,3 +2,7 @@
 **Learning:** Checking `Auth::user()->unreadNotifications->count()` inside the navigation layout triggers an N+1 query issue since notifications might not be loaded, and `count()` triggers a separate count query on the relation each time it's called (or loads all notifications). Actually, it loads the relation because it uses the property `unreadNotifications` and then calls `count()` on the collection. In this case, `unreadNotifications()->count()` is much more efficient as it performs an aggregate query, but even better is doing it right in a View Composer if needed, or just `unreadNotifications()->count()`. Wait, since it's `Auth::user()->unreadNotifications->count()`, it loads ALL unread notifications into memory just to count them!
 
 **Action:** Replace `$user->unreadNotifications->count()` with `$user->unreadNotifications()->count()`. This executes a simple `COUNT(*)` query without fetching the actual model records.
+
+## 2025-02-18 - [Repeated DB queries in loop]
+**Learning:** Calling `$item->images()->count()` inside a `foreach` loop triggers a new database query on each iteration. In scenarios where a user uploads multiple files (like 10 images), this causes an N+1 query anti-pattern even if the relation hasn't changed structure.
+**Action:** Cache the aggregate result (e.g. `$imageCount = $item->images()->count();`) before the loop, and use/increment this local variable within the loop to prevent repeated queries.

--- a/pifpaf/app/Http/Controllers/ItemController.php
+++ b/pifpaf/app/Http/Controllers/ItemController.php
@@ -406,9 +406,12 @@ class ItemController extends Controller
             // On récupère le dernier ordre pour continuer la séquence
             $order = $item->images()->max('order') + 1;
 
+            // ⚡ Bolt: Cache image count before loop to prevent repeated queries
+            $imageCount = $item->images()->count();
+
             foreach ($request->file('images') as $imageFile) {
                 // On vérifie qu'on ne dépasse pas la limite totale de 10 images
-                if ($item->images()->count() >= 10) {
+                if ($imageCount >= 10) {
                     break;
                 }
 
@@ -417,6 +420,8 @@ class ItemController extends Controller
                     'path' => $path,
                     'order' => $order++,
                 ]);
+
+                $imageCount++;
             }
         }
 


### PR DESCRIPTION
💡 What: Cached the image count in `$imageCount` before iterating over newly uploaded images in `ItemController::update` to manually track the current image limit threshold.

🎯 Why: Calling `$item->images()->count()` inside a `foreach` loop triggers a new `SELECT COUNT(*)` database query on each iteration. When multiple images are uploaded, this caused repeated queries. 

📊 Impact: Reduces N queries (where N is the number of uploaded images, up to 10 queries) to 1 query, slightly improving submission performance and memory tracking.

🔬 Measurement: View query logs when updating an item with multiple uploaded images and notice a single `SELECT COUNT(*)` for images instead of one per iteration. Also, no failures detected on the test suite.

---
*PR created automatically by Jules for task [7882153928292319328](https://jules.google.com/task/7882153928292319328) started by @Ganngann*