### PR TITLE
🎨 Palette: Standardize empty state component on purchases page

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-05-16 - Add ARIA Labels to Navigation Elements
 **Learning:** Icon-only links and toggle buttons (like the notifications bell and hamburger menu) are common in Laravel Breeze/Alpine navigation components but often lack accessible labels by default.
 **Action:** When adding or reviewing icon-only interactive elements, ensure `aria-label` is present. For elements that toggle state (like dropdowns or mobile menus), bind `aria-expanded` to the state variable (e.g., `:aria-expanded="open.toString()"` in Alpine.js) to communicate state to screen readers.
+
+## 2026-05-17 - Standardize Empty States
+**Learning:** Pages missing standard components like `x-ui.empty-state` make the app feel disjointed and unpolished when users encounter zero-data states (e.g. 0 purchases).
+**Action:** Always check views using `@empty` in Blade templates to ensure they use the `x-ui.empty-state` component rather than raw `<p>` tags for consistent visual communication.

--- a/pifpaf/resources/views/transactions/purchases.blade.php
+++ b/pifpaf/resources/views/transactions/purchases.blade.php
@@ -12,7 +12,9 @@
                     @forelse ($purchases as $transaction)
                         <x-purchase-card :transaction="$transaction" />
                     @empty
-                        <p>Vous n'avez effectué aucun achat pour le moment.</p>
+                        <x-ui.empty-state>
+                            Vous n'avez effectué aucun achat pour le moment.
+                        </x-ui.empty-state>
                     @endforelse
 
                     @if ($purchases->hasPages())


### PR DESCRIPTION
🎨 Palette: Standardize empty state on purchases page

**💡 What:**
Replaced the plain `<p>` tag ("Vous n'avez effectué aucun achat pour le moment.") with the application's standard `x-ui.empty-state` Blade component on the "Mes Achats" page (`resources/views/transactions/purchases.blade.php`). Also documented this learning in `.Jules/palette.md`.

**🎯 Why:**
To provide a more polished and consistent user experience. When users land on the purchases page with no prior transactions, they now see a nicely structured, visually distinct "empty state" card, matching the UX pattern already implemented on the "Mes Ventes" (sales) page. Consistency in visual communication helps orient the user and feels more professional.

**♿ Accessibility:**
No specific accessibility changes, but it uses the standard component which inherits the application's base design tokens.

**📸 Verification:**
The change was visually verified using Playwright locally to ensure the component renders correctly when a new user accesses the purchases page. All 226 backend tests (`php artisan test`) passed, ensuring no regressions.

---
*PR created automatically by Jules for task [5449794274700209576](https://jules.google.com/task/5449794274700209576) started by @Ganngann*