### PR TITLE
⚡ Bolt: Fix N+1 query in ItemController image upload loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -2,3 +2,8 @@
 **Learning:** Checking `Auth::user()->unreadNotifications->count()` inside the navigation layout triggers an N+1 query issue since notifications might not be loaded, and `count()` triggers a separate count query on the relation each time it's called (or loads all notifications). Actually, it loads the relation because it uses the property `unreadNotifications` and then calls `count()` on the collection. In this case, `unreadNotifications()->count()` is much more efficient as it performs an aggregate query, but even better is doing it right in a View Composer if needed, or just `unreadNotifications()->count()`. Wait, since it's `Auth::user()->unreadNotifications->count()`, it loads ALL unread notifications into memory just to count them!
 
 **Action:** Replace `$user->unreadNotifications->count()` with `$user->unreadNotifications()->count()`. This executes a simple `COUNT(*)` query without fetching the actual model records.
+
+## 2024-05-18 - [N+1 query in file upload loop]
+**Learning:** Using `$model->relation()->count()` inside a loop (like iterating through uploaded files) triggers a new `COUNT(*)` database query on every iteration. This creates an N+1 query issue, which degrades performance as the loop size grows.
+
+**Action:** Cache the initial count before the loop (`$currentCount = $model->relation()->count();`) and manually increment the cached variable inside the loop (`$currentCount++;`) when inserting new records.

--- a/pifpaf/app/Http/Controllers/ItemController.php
+++ b/pifpaf/app/Http/Controllers/ItemController.php
@@ -406,9 +406,12 @@ class ItemController extends Controller
             // On récupère le dernier ordre pour continuer la séquence
             $order = $item->images()->max('order') + 1;
 
+            // ⚡ Bolt: Cache current image count before loop to prevent N+1 queries during upload
+            $currentImageCount = $item->images()->count();
+
             foreach ($request->file('images') as $imageFile) {
                 // On vérifie qu'on ne dépasse pas la limite totale de 10 images
-                if ($item->images()->count() >= 10) {
+                if ($currentImageCount >= 10) {
                     break;
                 }
 
@@ -417,6 +420,7 @@ class ItemController extends Controller
                     'path' => $path,
                     'order' => $order++,
                 ]);
+                $currentImageCount++;
             }
         }
 


### PR DESCRIPTION
💡 What: Replaced `$item->images()->count()` inside the file upload loop with a cached `$currentImageCount` variable in `ItemController.php`.
🎯 Why: The previous code triggered an N+1 query issue, executing a new `COUNT(*)` database query on each iteration.
📊 Impact: Reduces database queries during image uploads from N (number of files) to 1.
🔬 Measurement: Run the test suite and observe database query logs.

---
*PR created automatically by Jules for task [14200515563072999138](https://jules.google.com/task/14200515563072999138) started by @Ganngann*