### PR TITLE
⚡ Bolt: Fix N+1 query during image upload

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -2,3 +2,7 @@
 **Learning:** Checking `Auth::user()->unreadNotifications->count()` inside the navigation layout triggers an N+1 query issue since notifications might not be loaded, and `count()` triggers a separate count query on the relation each time it's called (or loads all notifications). Actually, it loads the relation because it uses the property `unreadNotifications` and then calls `count()` on the collection. In this case, `unreadNotifications()->count()` is much more efficient as it performs an aggregate query, but even better is doing it right in a View Composer if needed, or just `unreadNotifications()->count()`. Wait, since it's `Auth::user()->unreadNotifications->count()`, it loads ALL unread notifications into memory just to count them!
 
 **Action:** Replace `$user->unreadNotifications->count()` with `$user->unreadNotifications()->count()`. This executes a simple `COUNT(*)` query without fetching the actual model records.
+
+## 2024-05-20 - [N+1 queries during image upload in ItemController]
+**Learning:** In `ItemController::update`, when adding new images to an item, there's a loop over the uploaded images. Inside the loop, it checks if the limit of 10 images has been reached using `$item->images()->count()`. This executes a `COUNT` query in the database for *every* uploaded image.
+**Action:** Always cache the initial count of related models before entering a loop and increment the cached value inside the loop to avoid N+1 query performance issues.

--- a/pifpaf/app/Http/Controllers/ItemController.php
+++ b/pifpaf/app/Http/Controllers/ItemController.php
@@ -405,10 +405,11 @@ class ItemController extends Controller
         if ($request->hasFile('images')) {
             // On récupère le dernier ordre pour continuer la séquence
             $order = $item->images()->max('order') + 1;
+            $currentImageCount = $item->images()->count();
 
             foreach ($request->file('images') as $imageFile) {
                 // On vérifie qu'on ne dépasse pas la limite totale de 10 images
-                if ($item->images()->count() >= 10) {
+                if ($currentImageCount >= 10) {
                     break;
                 }
 
@@ -417,6 +418,8 @@ class ItemController extends Controller
                     'path' => $path,
                     'order' => $order++,
                 ]);
+
+                $currentImageCount++;
             }
         }
 

--- a/pifpaf/tests/Feature/ImageUploadNPlusOneTest.php
+++ b/pifpaf/tests/Feature/ImageUploadNPlusOneTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Item;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class ImageUploadNPlusOneTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_image_upload_n_plus_one()
+    {
+        Storage::fake('public');
+        $user = User::factory()->create();
+        $item = Item::factory()->create(['user_id' => $user->id]);
+
+        $this->actingAs($user);
+
+        $images = [];
+        for ($i = 0; $i < 5; $i++) {
+            $images[] = UploadedFile::fake()->image('image'.$i.'.jpg');
+        }
+
+        DB::enableQueryLog();
+        $response = $this->put(route('items.update', $item), [
+            'title' => 'Updated Title',
+            'description' => 'Updated Description',
+            'category' => 'Autre',
+            'price' => 10,
+            'images' => $images,
+        ]);
+        $response->assertRedirect();
+
+        $queries = DB::getQueryLog();
+        $countQueries = 0;
+        foreach ($queries as $query) {
+            if (strpos($query['query'], 'select count(*) as aggregate from "item_images"') !== false) {
+                $countQueries++;
+            }
+        }
+
+        $this->assertTrue($countQueries <= 1, "Too many count queries: " . $countQueries);
+    }
+}


### PR DESCRIPTION
💡 What: Replaced `$item->images()->count()` inside the `foreach` loop with a pre-cached `$currentImageCount` variable that is manually incremented. Also added a new automated feature test to prevent regressions.

🎯 Why: To fix an N+1 query issue during bulk image uploads where a new database `COUNT` query was executed for every single uploaded image.

📊 Impact: Reduces the number of database queries executed when uploading new images from O(N) to O(1), improving performance and lowering database load during item modifications.

🔬 Measurement: A new feature test `tests/Feature/ImageUploadNPlusOneTest.php` has been added which captures the database query log and explicitly asserts that at most one `COUNT` aggregate query is executed for `item_images`.

---
*PR created automatically by Jules for task [11746114368326629496](https://jules.google.com/task/11746114368326629496) started by @Ganngann*