### PR TITLE
🎨 Palette: Improve empty state consistency in profile and item lists

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-21 - Consolidating empty states
+**Learning:** Found existing plain text empty states (`Aucun article trouvé.`, `Cet utilisateur n'a pas encore reçu d'avis.`) instead of utilizing the robust `<x-ui.empty-state>` design system component.
+**Action:** Replaced plain text with `<x-ui.empty-state>` for better visual presentation, structure, and consistency without inventing new CSS classes.

--- a/pifpaf/resources/views/components/item-list.blade.php
+++ b/pifpaf/resources/views/components/item-list.blade.php
@@ -4,8 +4,8 @@
     @forelse ($items as $item)
         <x-ui.item-card :item="$item" />
     @empty
-        <div class="col-span-full text-center text-gray-500">
-            <p>Aucun article trouvé.</p>
+        <div class="col-span-full">
+            <x-ui.empty-state>Aucun article trouvé.</x-ui.empty-state>
         </div>
     @endforelse
 </div>

--- a/pifpaf/resources/views/profile/show.blade.php
+++ b/pifpaf/resources/views/profile/show.blade.php
@@ -28,7 +28,7 @@
                         <p class="text-gray-700">{{ $review->comment }}</p>
                     </div>
                 @empty
-                    <p>Cet utilisateur n'a pas encore reçu d'avis.</p>
+                    <x-ui.empty-state>Cet utilisateur n'a pas encore reçu d'avis.</x-ui.empty-state>
                 @endforelse
             </div>
 


### PR DESCRIPTION
💡 **What**: Refactored plain text empty states (`<p>Aucun article trouvé.</p>` and `<p>Cet utilisateur n'a pas encore reçu d'avis.</p>`) to use the application's standard `<x-ui.empty-state>` Blade component.

🎯 **Why**: To provide consistent visual feedback, better spacing, and overall UI polish when collections (like user items or reviews) are empty. It utilizes the existing design system rather than floating plain text.

📸 **Before/After**: Visually verified using Playwright screenshots. The new empty states display within dashed bounding boxes, centering the text properly.

♿ **Accessibility**: Provides a structurally clearer empty state that fits seamlessly into the document flow.

---
*PR created automatically by Jules for task [10029584746550946626](https://jules.google.com/task/10029584746550946626) started by @Ganngann*