### PR TITLE
⚡ Bolt: Optimize N+1 query in ItemController file upload

### DIFF
--- a/pifpaf/app/Http/Controllers/ItemController.php
+++ b/pifpaf/app/Http/Controllers/ItemController.php
@@ -405,10 +405,12 @@ class ItemController extends Controller
         if ($request->hasFile('images')) {
             // On récupère le dernier ordre pour continuer la séquence
             $order = $item->images()->max('order') + 1;
+            $currentImageCount = $item->images()->count();
 
             foreach ($request->file('images') as $imageFile) {
                 // On vérifie qu'on ne dépasse pas la limite totale de 10 images
-                if ($item->images()->count() >= 10) {
+                // Optimisation: Utilisation d'une variable locale pour éviter une requête N+1
+                if ($currentImageCount >= 10) {
                     break;
                 }
 
@@ -417,6 +419,7 @@ class ItemController extends Controller
                     'path' => $path,
                     'order' => $order++,
                 ]);
+                $currentImageCount++;
             }
         }
 


### PR DESCRIPTION
💡 What: Extracted the `$item->images()->count()` method call from the file upload loop in `ItemController::update` and replaced it with a local counter variable.
🎯 Why: The previous implementation executed an aggregate database query (`SELECT COUNT(*)`) for every file processed within the loop, causing an N+1 query issue.
📊 Impact: Reduces database queries during item updates with multiple images from O(N) to O(1) for the image count check.
🔬 Measurement: Verify by uploading multiple images when editing an item and observing the number of database queries executed. The `ItemControllerTest` suite continues to pass without regressions.

---
*PR created automatically by Jules for task [8192556712531116576](https://jules.google.com/task/8192556712531116576) started by @Ganngann*