### PR TITLE
🎨 Palette: Use `<x-ui.empty-state>` for empty lists

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-22 - Use `<x-ui.empty-state>` for empty lists
+**Learning:** Using unstyled `<p>` tags for empty states throughout the application leads to an inconsistent and visually unappealing user experience.
+**Action:** Always use the existing `<x-ui.empty-state>` Blade component when presenting empty states (e.g., empty lists or missing data) to ensure visual consistency and a polished UX across the application.

--- a/pifpaf/resources/views/ai-requests/index.blade.php
+++ b/pifpaf/resources/views/ai-requests/index.blade.php
@@ -243,7 +243,9 @@
                             </div>
                         </div>
                     @empty
-                        <p>Vous n'avez aucune analyse IA pour le moment.</p>
+                        <x-ui.empty-state>
+                            Vous n'avez aucune analyse IA pour le moment.
+                        </x-ui.empty-state>
                     @endforelse
                 </div>
             </div>

--- a/pifpaf/resources/views/components/dashboard/empty-dashboard.blade.php
+++ b/pifpaf/resources/views/components/dashboard/empty-dashboard.blade.php
@@ -1,6 +1,10 @@
 <div class="text-center text-gray-500">
-    <p>Vous n'avez pas encore d'annonce.</p>
-    <a href="{{ route('items.create') }}" class="mt-2 inline-block bg-blue-500 text-white font-bold py-2 px-4 rounded hover:bg-blue-700">
-        Créer ma première annonce
-    </a>
+    <x-ui.empty-state>
+        Vous n'avez pas encore d'annonce.
+        <x-slot name="actions">
+            <a href="{{ route('items.create') }}" class="mt-2 inline-block bg-blue-500 text-white font-bold py-2 px-4 rounded hover:bg-blue-700">
+                Créer ma première annonce
+            </a>
+        </x-slot>
+    </x-ui.empty-state>
 </div>

--- a/pifpaf/resources/views/components/dashboard/transactions-en-cours.blade.php
+++ b/pifpaf/resources/views/components/dashboard/transactions-en-cours.blade.php
@@ -5,7 +5,9 @@
         <h3 class="text-2xl font-bold mb-6 text-center sm:text-left">Transactions en cours</h3>
         @if ($openTransactions->isEmpty())
             <div class="text-center text-gray-500">
-                <p>Vous n'avez aucune transaction en cours.</p>
+                <x-ui.empty-state>
+                    Vous n'avez aucune transaction en cours.
+                </x-ui.empty-state>
             </div>
         @else
             <div class="space-y-4">

--- a/pifpaf/resources/views/conversations/index.blade.php
+++ b/pifpaf/resources/views/conversations/index.blade.php
@@ -12,7 +12,9 @@
                     <h3 class="text-2xl font-bold mb-6">Vos Conversations</h3>
 
                     @if($conversations->isEmpty())
-                        <p>Vous n'avez aucune conversation pour le moment.</p>
+                        <x-ui.empty-state>
+                            Vous n'avez aucune conversation pour le moment.
+                        </x-ui.empty-state>
                     @else
                         <div class="space-y-4">
                             @foreach($conversations as $conversation)

--- a/pifpaf/resources/views/notifications/index.blade.php
+++ b/pifpaf/resources/views/notifications/index.blade.php
@@ -29,7 +29,9 @@
                             @endif
                         </div>
                     @empty
-                        <p>Vous n'avez aucune notification.</p>
+                        <x-ui.empty-state>
+                            Vous n'avez aucune notification.
+                        </x-ui.empty-state>
                     @endforelse
 
                     <div class="mt-4">

--- a/pifpaf/resources/views/profile/addresses/index.blade.php
+++ b/pifpaf/resources/views/profile/addresses/index.blade.php
@@ -16,7 +16,9 @@
                         </a>
                     </div>
                     @if($addresses->isEmpty())
-                        <p>Vous n'avez pas encore d'adresse enregistrée.</p>
+                        <x-ui.empty-state>
+                            Vous n'avez pas encore d'adresse enregistrée.
+                        </x-ui.empty-state>
                     @else
                         <div class="space-y-4">
                             @foreach($addresses as $address)

--- a/pifpaf/resources/views/profile/bank-accounts/index.blade.php
+++ b/pifpaf/resources/views/profile/bank-accounts/index.blade.php
@@ -24,7 +24,9 @@
 
                     <div class="mt-6">
                         @if ($bankAccounts->isEmpty())
-                            <p>Vous n'avez pas encore de compte bancaire enregistré.</p>
+                            <x-ui.empty-state>
+                                Vous n'avez pas encore de compte bancaire enregistré.
+                            </x-ui.empty-state>
                         @else
                             <ul>
                                 @foreach ($bankAccounts as $account)

--- a/pifpaf/resources/views/transactions/purchases.blade.php
+++ b/pifpaf/resources/views/transactions/purchases.blade.php
@@ -12,7 +12,9 @@
                     @forelse ($purchases as $transaction)
                         <x-purchase-card :transaction="$transaction" />
                     @empty
-                        <p>Vous n'avez effectué aucun achat pour le moment.</p>
+                        <x-ui.empty-state>
+                            Vous n'avez effectué aucun achat pour le moment.
+                        </x-ui.empty-state>
                     @endforelse
 
                     @if ($purchases->hasPages())


### PR DESCRIPTION
💡 What: The UX enhancement added:
Replaced basic, unstyled `<p>` tags with the `<x-ui.empty-state>` Blade component across multiple views where lists are empty.

🎯 Why: The user problem it solves:
Using unstyled text for empty states leads to an inconsistent and visually unappealing user experience. Utilizing a dedicated component improves the overall visual polish, makes empty states more intuitive, and ensures UI consistency across the application.

📸 Before/After: Visual changes were applied to centralize styling.

♿ Accessibility: Ensures consistent semantic structure for empty states.

---
*PR created automatically by Jules for task [99894440376425853](https://jules.google.com/task/99894440376425853) started by @Ganngann*