### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Insecure Direct Object Reference (IDOR) via image_path

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,8 @@
 **Vulnerability:** The application had a critical path traversal vulnerability in `AiRequestController.php` and `ItemController.php` where user-controlled input (`image_path`, `original_image_path`) was passed directly to `Storage::disk('public')->path()` and `Storage::disk('public')->move()` without proper sanitization. This allowed attackers to potentially read or move arbitrary files on the server using `../../` sequences.
 **Learning:** Even when using Laravel's storage facade, unsanitized user input passed to methods like `path()`, `exists()`, or `move()` is unsafe. Path parameters received from external requests must be strictly validated.
 **Prevention:** Always validate file paths from external input using strict regex constraints (e.g., `regex:/^ai_images\/[a-zA-Z0-9_\-\.]+$/`) to ensure they only point to expected directories and do not contain directory traversal sequences.
+
+## 2026-05-23 - [Fix Insecure Direct Object Reference (IDOR) via image_path]
+**Vulnerability:** The application had an IDOR vulnerability in `AiRequestController@cropPreview` and `ItemController@store` where users could manipulate the `image_path` parameter to access or use AI generated images belonging to other users. The system only checked if the file existed, not who owned it.
+**Learning:** When retrieving files or models using secondary identifiers like a file path rather than a primary key, it is crucial to perform an ownership check against the current authenticated user.
+**Prevention:** Always query the database to verify the ownership of an entity before performing actions on it, especially when the identifier is provided via user input (like `image_path`). Check that `user_id === Auth::id()`, and abort with 403 if they don't match.

--- a/pifpaf/app/Http/Controllers/AiRequestController.php
+++ b/pifpaf/app/Http/Controllers/AiRequestController.php
@@ -60,6 +60,11 @@ class AiRequestController extends Controller
 
         $originalPath = $validated['image_path'];
 
+        $aiRequest = AiRequest::where('image_path', $originalPath)->first();
+        if (!$aiRequest || $aiRequest->user_id !== Auth::id()) {
+            abort(403, 'Unauthorized access to this image.');
+        }
+
         if (!Storage::disk('public')->exists($originalPath)) {
             return response('Image not found.', 404);
         }

--- a/pifpaf/app/Http/Controllers/ItemController.php
+++ b/pifpaf/app/Http/Controllers/ItemController.php
@@ -328,6 +328,12 @@ class ItemController extends Controller
         // 1. Gérer l'image venant du flux IA
         if ($request->has('image_path')) {
             $tempPath = $request->input('image_path');
+
+            $aiRequest = \App\Models\AiRequest::where('image_path', $tempPath)->first();
+            if (!$aiRequest || $aiRequest->user_id !== Auth::id()) {
+                abort(403, 'Unauthorized access to this image.');
+            }
+
             if (Storage::disk('public')->exists($tempPath)) {
                 $newPath = "item_images/{$item->id}/" . basename($tempPath);
                 Storage::disk('public')->move($tempPath, $newPath);

--- a/pifpaf/routes/web.php
+++ b/pifpaf/routes/web.php
@@ -102,9 +102,9 @@ Route::middleware('auth')->group(function () {
     // Routes pour les notifications
     Route::get('/notifications', [NotificationController::class, 'index'])->name('notifications.index');
     Route::patch('/notifications/{id}/read', [NotificationController::class, 'markAsRead'])->name('notifications.read');
-});
 
-Route::get('/ai-requests/crop-preview', [AiRequestController::class, 'cropPreview'])->name('ai.requests.crop_preview');
+    Route::get('/ai-requests/crop-preview', [AiRequestController::class, 'cropPreview'])->name('ai.requests.crop_preview');
+});
 
 Route::get('/items/{item}', [ItemController::class, 'show'])->name('items.show');
 Route::get('/profile/{user}', [ProfileController::class, 'show'])->name('profile.show');


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The application had an IDOR vulnerability in `AiRequestController@cropPreview` and `ItemController@store` where users could manipulate the `image_path` parameter to access or use AI generated images belonging to other users. The system only checked if the file existed, not who owned it.
🎯 Impact: Attackers could potentially view, steal, or assign other users' generated AI images to their own items.
🔧 Fix: 
1. Moved the `/ai-requests/crop-preview` route inside the `auth` middleware group to prevent unauthenticated access.
2. Added ownership verification in `AiRequestController@cropPreview` and `ItemController@store`. It now queries the `AiRequest` by `image_path` and asserts that `user_id === Auth::id()`, returning a 403 Forbidden error otherwise.
✅ Verification: Ensure the test suite passes (`php artisan test`). To test manually, try to crop or save an item using an `image_path` that belongs to a different user's `AiRequest`; it should fail with a 403 error.

---
*PR created automatically by Jules for task [16957574257359135725](https://jules.google.com/task/16957574257359135725) started by @Ganngann*