### PR TITLE
🎨 Palette: Replace unstyled empty state in purchases with x-ui.empty-state component

### DIFF
--- a/pifpaf/resources/views/transactions/purchases.blade.php
+++ b/pifpaf/resources/views/transactions/purchases.blade.php
@@ -12,7 +12,9 @@
                     @forelse ($purchases as $transaction)
                         <x-purchase-card :transaction="$transaction" />
                     @empty
-                        <p>Vous n'avez effectué aucun achat pour le moment.</p>
+                        <x-ui.empty-state>
+                            Vous n'avez effectué aucun achat pour le moment.
+                        </x-ui.empty-state>
                     @endforelse
 
                     @if ($purchases->hasPages())


### PR DESCRIPTION
**💡 What:** Replaced the unstyled text `<p>` tag in the purchases view with the standard `x-ui.empty-state` component.
**🎯 Why:** To improve visual consistency across the application when displaying empty states (similar to what is done in `sales.blade.php`), and to present a more polished interface to users who haven't made any purchases yet.
**♿ Accessibility:** N/A for this specific change (purely visual layout improvement).

---
*PR created automatically by Jules for task [9979951302713464644](https://jules.google.com/task/9979951302713464644) started by @Ganngann*