### PR TITLE
🎨 Palette: Standardize Empty States with CTAs

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-23 - Empty State Component Standard
+**Learning:** When implementing empty states using the `x-ui.empty-state` component, always include a helpful call-to-action (CTA) rather than merely wrapping the existing empty state text, as the CTA provides the primary UX value.
+**Action:** I will add CTA links to the newly wrapped `x-ui.empty-state` components to improve UX.

--- a/pifpaf/resources/views/ai-requests/index.blade.php
+++ b/pifpaf/resources/views/ai-requests/index.blade.php
@@ -243,7 +243,14 @@
                             </div>
                         </div>
                     @empty
-                        <p>Vous n'avez aucune analyse IA pour le moment.</p>
+                        <x-ui.empty-state>
+                            Vous n'avez aucune analyse IA pour le moment.
+                            <x-slot name="actions">
+                                <a href="{{ route('items.create-with-ai') }}" class="inline-flex items-center px-4 py-2 bg-indigo-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-700 active:bg-indigo-900 focus:outline-none focus:border-indigo-900 focus:ring ring-indigo-300 disabled:opacity-25 transition ease-in-out duration-150">
+                                    Essayer l'analyse IA
+                                </a>
+                            </x-slot>
+                        </x-ui.empty-state>
                     @endforelse
                 </div>
             </div>

--- a/pifpaf/resources/views/components/item-list.blade.php
+++ b/pifpaf/resources/views/components/item-list.blade.php
@@ -4,8 +4,15 @@
     @forelse ($items as $item)
         <x-ui.item-card :item="$item" />
     @empty
-        <div class="col-span-full text-center text-gray-500">
-            <p>Aucun article trouvé.</p>
+        <div class="col-span-full">
+            <x-ui.empty-state>
+                Aucun article trouvé.
+                <x-slot name="actions">
+                    <a href="{{ route('welcome') }}" class="text-sm font-medium text-indigo-600 hover:text-indigo-500">
+                        Réinitialiser la recherche
+                    </a>
+                </x-slot>
+            </x-ui.empty-state>
         </div>
     @endforelse
 </div>

--- a/pifpaf/resources/views/notifications/index.blade.php
+++ b/pifpaf/resources/views/notifications/index.blade.php
@@ -29,7 +29,9 @@
                             @endif
                         </div>
                     @empty
-                        <p>Vous n'avez aucune notification.</p>
+                        <x-ui.empty-state>
+                            Vous n'avez aucune notification.
+                        </x-ui.empty-state>
                     @endforelse
 
                     <div class="mt-4">

--- a/pifpaf/resources/views/profile/show.blade.php
+++ b/pifpaf/resources/views/profile/show.blade.php
@@ -28,7 +28,9 @@
                         <p class="text-gray-700">{{ $review->comment }}</p>
                     </div>
                 @empty
-                    <p>Cet utilisateur n'a pas encore reçu d'avis.</p>
+                    <x-ui.empty-state>
+                        Cet utilisateur n'a pas encore reçu d'avis.
+                    </x-ui.empty-state>
                 @endforelse
             </div>
 

--- a/pifpaf/resources/views/transactions/purchases.blade.php
+++ b/pifpaf/resources/views/transactions/purchases.blade.php
@@ -12,7 +12,14 @@
                     @forelse ($purchases as $transaction)
                         <x-purchase-card :transaction="$transaction" />
                     @empty
-                        <p>Vous n'avez effectué aucun achat pour le moment.</p>
+                        <x-ui.empty-state>
+                            Vous n'avez effectué aucun achat pour le moment.
+                            <x-slot name="actions">
+                                <a href="{{ route('welcome') }}" class="inline-flex items-center px-4 py-2 bg-indigo-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-700 active:bg-indigo-900 focus:outline-none focus:border-indigo-900 focus:ring ring-indigo-300 disabled:opacity-25 transition ease-in-out duration-150">
+                                    Trouver des articles
+                                </a>
+                            </x-slot>
+                        </x-ui.empty-state>
                     @endforelse
 
                     @if ($purchases->hasPages())

--- a/pifpaf/resources/views/transactions/sales.blade.php
+++ b/pifpaf/resources/views/transactions/sales.blade.php
@@ -16,6 +16,11 @@
                     @empty
                         <x-ui.empty-state>
                             Vous n'avez réalisé aucune vente pour le moment.
+                            <x-slot name="actions">
+                                <a href="{{ route('items.create') }}" class="inline-flex items-center px-4 py-2 bg-indigo-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-700 active:bg-indigo-900 focus:outline-none focus:border-indigo-900 focus:ring ring-indigo-300 disabled:opacity-25 transition ease-in-out duration-150">
+                                    Vendre un article
+                                </a>
+                            </x-slot>
                         </x-ui.empty-state>
                     @endforelse
 


### PR DESCRIPTION
💡 **What:** Standardized the empty state presentation across multiple lists by replacing unstyled `<p>` tags with the `x-ui.empty-state` component and integrating helpful Calls to Action (CTAs).

🎯 **Why:** To improve UX and visual consistency. Users who encounter empty lists (like 0 purchases or no search results) now receive a better visual cue alongside a clear next action, preventing dead-ends. 

This UX change implements the 'Add empty state with helpful call-to-action' recommendation.

---
*PR created automatically by Jules for task [4155379658415105222](https://jules.google.com/task/4155379658415105222) started by @Ganngann*