### PR TITLE
🎨 Palette: Improve Empty State UX

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,5 @@
+## 2025-05-25 - Improved Empty State Components
+
+**Learning:** Using simple paragraph tags for empty lists creates poor UX and dead ends. When replacing them with `x-ui.empty-state`, always include an actionable Call-To-Action (CTA) in the `<x-slot name="actions">`. Additionally, conditionally hide any top-level "Add" or "Create" buttons when the empty state is visible to prevent confusing duplicate actions.
+
+**Action:** Whenever implementing a list view, check if an empty state exists and ensure it uses the `x-ui.empty-state` pattern with a clear CTA guiding the user to their next logical action.

--- a/pifpaf/resources/views/profile/addresses/index.blade.php
+++ b/pifpaf/resources/views/profile/addresses/index.blade.php
@@ -11,12 +11,24 @@
                 <div class="p-6 bg-white border-b border-gray-200">
                     <div class="flex justify-between items-center mb-4">
                         <h3 class="text-lg font-semibold">Toutes mes adresses</h3>
-                        <a href="{{ route('profile.addresses.create') }}" class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 active:bg-gray-900 focus:outline-none focus:border-gray-900 focus:ring ring-gray-300 disabled:opacity-25 transition ease-in-out duration-150">
-                            Ajouter une adresse
-                        </a>
+                        @if($addresses->isNotEmpty())
+                            <a href="{{ route('profile.addresses.create') }}" class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 active:bg-gray-900 focus:outline-none focus:border-gray-900 focus:ring ring-gray-300 disabled:opacity-25 transition ease-in-out duration-150">
+                                Ajouter une adresse
+                            </a>
+                        @endif
                     </div>
                     @if($addresses->isEmpty())
-                        <p>Vous n'avez pas encore d'adresse enregistrée.</p>
+                        <x-ui.empty-state>
+                            <x-slot name="icon">
+                                <svg class="w-full h-full" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"></path><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"></path></svg>
+                            </x-slot>
+                            Vous n'avez pas encore d'adresse enregistrée.
+                            <x-slot name="actions">
+                                <a href="{{ route('profile.addresses.create') }}" class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 active:bg-gray-900 focus:outline-none focus:border-gray-900 focus:ring ring-gray-300 disabled:opacity-25 transition ease-in-out duration-150">
+                                    Ajouter une adresse
+                                </a>
+                            </x-slot>
+                        </x-ui.empty-state>
                     @else
                         <div class="space-y-4">
                             @foreach($addresses as $address)

--- a/pifpaf/resources/views/transactions/purchases.blade.php
+++ b/pifpaf/resources/views/transactions/purchases.blade.php
@@ -12,7 +12,17 @@
                     @forelse ($purchases as $transaction)
                         <x-purchase-card :transaction="$transaction" />
                     @empty
-                        <p>Vous n'avez effectué aucun achat pour le moment.</p>
+                        <x-ui.empty-state>
+                            <x-slot name="icon">
+                                <svg class="w-full h-full" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 11V7a4 4 0 00-8 0v4M5 9h14l1 12H4L5 9z"></path></svg>
+                            </x-slot>
+                            Vous n'avez effectué aucun achat pour le moment.
+                            <x-slot name="actions">
+                                <a href="{{ route('welcome') }}" class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 active:bg-gray-900 focus:outline-none focus:border-gray-900 focus:ring ring-gray-300 disabled:opacity-25 transition ease-in-out duration-150">
+                                    Retour à l'accueil
+                                </a>
+                            </x-slot>
+                        </x-ui.empty-state>
                     @endforelse
 
                     @if ($purchases->hasPages())


### PR DESCRIPTION
Replaced generic `<p>` tag empty states with the project's standard `x-ui.empty-state` component. Added appropriate SVG icons and clear Call-To-Action (CTA) buttons to guide users. Also conditionally hid the top-level 'Add Address' button when the empty state is visible to prevent duplicate CTAs.

---
*PR created automatically by Jules for task [13038558365716690458](https://jules.google.com/task/13038558365716690458) started by @Ganngann*