### PR TITLE
⚡ Bolt: Fix N+1 query in item image upload

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -2,3 +2,7 @@
 **Learning:** Checking `Auth::user()->unreadNotifications->count()` inside the navigation layout triggers an N+1 query issue since notifications might not be loaded, and `count()` triggers a separate count query on the relation each time it's called (or loads all notifications). Actually, it loads the relation because it uses the property `unreadNotifications` and then calls `count()` on the collection. In this case, `unreadNotifications()->count()` is much more efficient as it performs an aggregate query, but even better is doing it right in a View Composer if needed, or just `unreadNotifications()->count()`. Wait, since it's `Auth::user()->unreadNotifications->count()`, it loads ALL unread notifications into memory just to count them!
 
 **Action:** Replace `$user->unreadNotifications->count()` with `$user->unreadNotifications()->count()`. This executes a simple `COUNT(*)` query without fetching the actual model records.
+
+## 2025-01-20 - [N+1 query in item image upload loop]
+**Learning:** Checking `$item->images()->count()` inside a `foreach` loop that iterates over uploaded files triggers an N+1 query issue, executing a new `COUNT` query for each file to enforce the maximum image limit.
+**Action:** Extract `$item->images()->count()` into a local variable before the loop, and use/increment this local variable within the loop to eliminate redundant database queries.

--- a/pifpaf/app/Http/Controllers/ItemController.php
+++ b/pifpaf/app/Http/Controllers/ItemController.php
@@ -405,10 +405,11 @@ class ItemController extends Controller
         if ($request->hasFile('images')) {
             // On récupère le dernier ordre pour continuer la séquence
             $order = $item->images()->max('order') + 1;
+            $currentImageCount = $item->images()->count();
 
             foreach ($request->file('images') as $imageFile) {
                 // On vérifie qu'on ne dépasse pas la limite totale de 10 images
-                if ($item->images()->count() >= 10) {
+                if ($currentImageCount >= 10) {
                     break;
                 }
 
@@ -417,6 +418,7 @@ class ItemController extends Controller
                     'path' => $path,
                     'order' => $order++,
                 ]);
+                $currentImageCount++;
             }
         }
 


### PR DESCRIPTION
💡 What: Extracted the `$item->images()->count()` call from inside the image upload loop in `ItemController@update` into a local variable before the loop, incrementing it directly during the iteration.
🎯 Why: Calling `$item->images()->count()` inside a `foreach` loop that iterates over each uploaded file caused an N+1 query problem by executing a new `COUNT` query on the database for every single file.
📊 Impact: Completely eliminates redundant `COUNT(*)` queries during item updates when uploading multiple files, reducing database load and response time.
🔬 Measurement: Verified by running `php artisan test` to ensure that the image limitation logic remains identical. You can also view query logs in Laravel Telescope or use `\DB::enableQueryLog()` during an update process with multiple images to see that only a single initial query is performed.

---
*PR created automatically by Jules for task [11990822873354045177](https://jules.google.com/task/11990822873354045177) started by @Ganngann*