### PR TITLE
🎨 Palette: Add empty state with CTA to Profile Addresses and Bank Accounts

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,6 @@
+## 2026-05-27 - Adding actions inside Empty State components
+**Learning:** It is crucial to conditionally hide top-level action buttons when a list is empty and the empty state component () incorporates its own primary Call to Action button. Leaving both buttons visible simultaneously clutters the UI and confuses the user with duplicated primary actions on the screen.
+**Action:** When replacing unstyled empty states with a dedicated component containing a CTA, always ensure the original page-level action button is hidden using conditional logic (e.g., `@if($collection->isNotEmpty())`).
+## 2026-05-27 - Adding actions inside Empty State components
+**Learning:** It is crucial to conditionally hide top-level action buttons when a list is empty and the empty state component (x-ui.empty-state) incorporates its own primary Call to Action button. Leaving both buttons visible simultaneously clutters the UI and confuses the user with duplicated primary actions on the screen.
+**Action:** When replacing unstyled empty states with a dedicated component containing a CTA, always ensure the original page-level action button is hidden using conditional logic (e.g., @if($collection->isNotEmpty())).

--- a/pifpaf/resources/views/profile/addresses/index.blade.php
+++ b/pifpaf/resources/views/profile/addresses/index.blade.php
@@ -11,12 +11,27 @@
                 <div class="p-6 bg-white border-b border-gray-200">
                     <div class="flex justify-between items-center mb-4">
                         <h3 class="text-lg font-semibold">Toutes mes adresses</h3>
-                        <a href="{{ route('profile.addresses.create') }}" class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 active:bg-gray-900 focus:outline-none focus:border-gray-900 focus:ring ring-gray-300 disabled:opacity-25 transition ease-in-out duration-150">
-                            Ajouter une adresse
-                        </a>
+                        @if($addresses->isNotEmpty())
+                            <a href="{{ route('profile.addresses.create') }}" class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 active:bg-gray-900 focus:outline-none focus:border-gray-900 focus:ring ring-gray-300 disabled:opacity-25 transition ease-in-out duration-150">
+                                Ajouter une adresse
+                            </a>
+                        @endif
                     </div>
                     @if($addresses->isEmpty())
-                        <p>Vous n'avez pas encore d'adresse enregistrée.</p>
+                        <x-ui.empty-state>
+                            <x-slot name="icon">
+                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 mx-auto">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M15 10.5a3 3 0 11-6 0 3 3 0 016 0z" />
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 10.5c0 7.142-7.5 11.25-7.5 11.25S4.5 17.642 4.5 10.5a7.5 7.5 0 1115 0z" />
+                                </svg>
+                            </x-slot>
+                            Vous n'avez pas encore d'adresse enregistrée.
+                            <x-slot name="actions">
+                                <a href="{{ route('profile.addresses.create') }}" class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 active:bg-gray-900 focus:outline-none focus:border-gray-900 focus:ring ring-gray-300 disabled:opacity-25 transition ease-in-out duration-150">
+                                    Ajouter une adresse
+                                </a>
+                            </x-slot>
+                        </x-ui.empty-state>
                     @else
                         <div class="space-y-4">
                             @foreach($addresses as $address)

--- a/pifpaf/resources/views/profile/bank-accounts/index.blade.php
+++ b/pifpaf/resources/views/profile/bank-accounts/index.blade.php
@@ -11,9 +11,11 @@
                 <div class="p-6 bg-white border-b border-gray-200">
                     <div class="flex justify-between items-center mb-4">
                         <h3 class="text-lg font-medium text-gray-900">Vos comptes bancaires</h3>
-                        <a href="{{ route('profile.bank-accounts.create') }}" class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 active:bg-gray-900 focus:outline-none focus:border-gray-900 focus:ring ring-gray-300 disabled:opacity-25 transition ease-in-out duration-150">
-                            {{ __('Ajouter un compte') }}
-                        </a>
+                        @if($bankAccounts->isNotEmpty())
+                            <a href="{{ route('profile.bank-accounts.create') }}" class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 active:bg-gray-900 focus:outline-none focus:border-gray-900 focus:ring ring-gray-300 disabled:opacity-25 transition ease-in-out duration-150">
+                                {{ __('Ajouter un compte') }}
+                            </a>
+                        @endif
                     </div>
 
                     @if (session('success'))
@@ -24,7 +26,19 @@
 
                     <div class="mt-6">
                         @if ($bankAccounts->isEmpty())
-                            <p>Vous n'avez pas encore de compte bancaire enregistré.</p>
+                            <x-ui.empty-state>
+                                <x-slot name="icon">
+                                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 mx-auto">
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 8.25h19.5M2.25 9h19.5m-16.5 5.25h6m-6 2.25h3m-3.75 3h15a2.25 2.25 0 002.25-2.25V6.75A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25v10.5A2.25 2.25 0 004.5 19.5z" />
+                                    </svg>
+                                </x-slot>
+                                Vous n'avez pas encore de compte bancaire enregistré.
+                                <x-slot name="actions">
+                                    <a href="{{ route('profile.bank-accounts.create') }}" class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 active:bg-gray-900 focus:outline-none focus:border-gray-900 focus:ring ring-gray-300 disabled:opacity-25 transition ease-in-out duration-150">
+                                        {{ __('Ajouter un compte') }}
+                                    </a>
+                                </x-slot>
+                            </x-ui.empty-state>
                         @else
                             <ul>
                                 @foreach ($bankAccounts as $account)


### PR DESCRIPTION
🎨 **Palette: UX Improvement**

**💡 What:** 
Replaced the unstyled, plain text empty states on the Profile Addresses and Profile Bank Accounts pages with the standardized `x-ui.empty-state` component. 

**🎯 Why:** 
Previously, users encountering an empty list would see a simple line of text, and the primary call-to-action (CTA) to add an item was disconnected at the top of the page. By using the `x-ui.empty-state` component:
- The interface provides a much stronger, centralized visual cue.
- The Call to Action (adding an address or bank account) is placed directly within the empty state where the user is looking.
- To avoid clutter, the top-right CTA button is now dynamically hidden when the list is empty, preventing duplicated primary actions. 

**📸 Verification:** 
A playwright script was run to visually verify the frontend rendering of both empty states with test user accounts. Tests (`php artisan test`) also pass cleanly.

---
*PR created automatically by Jules for task [9276868877075670012](https://jules.google.com/task/9276868877075670012) started by @Ganngann*