### PR TITLE
🎨 Palette: Improve purchases empty state with actionable CTA

### DIFF
--- a/pifpaf/.jules/palette.md
+++ b/pifpaf/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-28 - Styled Links vs Primary Buttons
+**Learning:** The `<x-primary-button>` Blade component in this codebase only renders a `<button>` element and does not support rendering an `href` attribute to act as a link. When implementing call-to-actions (CTAs) within elements like empty states that require navigation, developers must extract and manually apply the button's Tailwind classes to a standard `<a>` tag to achieve visual consistency.
+**Action:** When adding link-based CTAs to UI components, avoid attempting to use `<x-primary-button href="...">`. Instead, directly apply the standard button utility classes (e.g., `inline-flex items-center px-4 py-2 bg-gray-800...`) to an anchor tag.

--- a/pifpaf/resources/views/transactions/purchases.blade.php
+++ b/pifpaf/resources/views/transactions/purchases.blade.php
@@ -12,7 +12,14 @@
                     @forelse ($purchases as $transaction)
                         <x-purchase-card :transaction="$transaction" />
                     @empty
-                        <p>Vous n'avez effectué aucun achat pour le moment.</p>
+                        <x-ui.empty-state>
+                            Vous n'avez effectué aucun achat pour le moment.
+                            <x-slot name="actions">
+                                <a href="{{ route('welcome') }}" class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 active:bg-gray-900 focus:outline-none focus:border-gray-900 focus:ring ring-gray-300 disabled:opacity-25 transition ease-in-out duration-150">
+                                    Découvrir les annonces
+                                </a>
+                            </x-slot>
+                        </x-ui.empty-state>
                     @endforelse
 
                     @if ($purchases->hasPages())


### PR DESCRIPTION
💡 What: The UX enhancement added
Replaced the plain text empty state on the purchases page with the styled `x-ui.empty-state` component and added a "Découvrir les annonces" CTA button.

🎯 Why: The user problem it solves
An unstyled text paragraph is easy to miss and feels like an unfinished UI state. More importantly, it leaves the user at a dead end. By adding a clear CTA, we guide users back into the core application flow (browsing items), improving engagement and the overall intuitiveness of the interface.

📸 Before/After: Screenshots if visual change
A verification screenshot has been generated and validated showing the new dashed container and prominent action button.

♿ Accessibility: Any a11y improvements made
The added CTA uses standard button styling applied to an anchor tag, ensuring it is keyboard focusable and readable by screen readers as a navigational link.

---
*PR created automatically by Jules for task [6650390842124114983](https://jules.google.com/task/6650390842124114983) started by @Ganngann*