### PR TITLE
🎨 Palette: Add ARIA attributes to User Navigation Dropdown

### DIFF
--- a/pifpaf/.jules/palette.md
+++ b/pifpaf/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-29 - WCAG 2.1 Success Criterion 2.5.3 (Label in Name)
+**Learning:** When improving accessibility by adding an `aria-label` to elements that contain visible dynamic text (such as a user's name), the `aria-label` must explicitly include that visible text to comply with WCAG 2.1 Success Criterion 2.5.3 (Label in Name) and prevent breaking voice control. For example, replacing a button containing `{{ Auth::user()->name }}` with an `aria-label="Menu utilisateur"` breaks voice control as the user cannot call it by the name displayed.
+**Action:** Always include the visible text in the `aria-label` string (e.g. `aria-label="Menu utilisateur pour {{ Auth::user()->name }}"`).

--- a/pifpaf/resources/views/layouts/navigation.blade.php
+++ b/pifpaf/resources/views/layouts/navigation.blade.php
@@ -41,7 +41,7 @@
 
                     <!-- Settings Dropdown -->
                     <div class="relative z-50" x-data="{ open: false }">
-                        <button @click="open = ! open" dusk="nav-user-dropdown" :aria-expanded="open.toString()" class="flex items-center text-sm font-medium text-gray-500 hover:text-gray-700 hover:border-gray-300 focus:outline-none focus:text-gray-700 focus:border-gray-300 transition duration-150 ease-in-out">
+                        <button @click="open = ! open" dusk="nav-user-dropdown" aria-haspopup="true" aria-label="Menu utilisateur pour {{ Auth::user()->name }}" :aria-expanded="open.toString()" class="flex items-center text-sm font-medium text-gray-500 hover:text-gray-700 hover:border-gray-300 focus:outline-none focus:text-gray-700 focus:border-gray-300 transition duration-150 ease-in-out">
                             <div>{{ Auth::user()->name }}</div>
 
                             <div class="ml-1">


### PR DESCRIPTION
🎨 Palette: [UX improvement] Add ARIA label and haspopup to User Navigation Dropdown

💡 **What:** Added `aria-haspopup="true"` and `aria-label="Menu utilisateur pour {{ Auth::user()->name }}"` to the user profile dropdown button in the navigation header.

🎯 **Why:** The button containing only the user's name visually functions as a toggle for a dropdown menu. Without an `aria-label`, screen readers merely read the user's name out of context. Adding an `aria-label` that includes the visual text ("Menu utilisateur pour [Name]") provides necessary context for screen reader users while complying with WCAG 2.5.3 (Label in Name), ensuring voice control users can still target the button. Adding `aria-haspopup="true"` signals that activating the button reveals a submenu.

📸 **Before/After:** No visual changes. This is an accessibility enhancement.

♿ **Accessibility:**
- Added `aria-haspopup="true"` to indicate a submenu.
- Added descriptive `aria-label` containing the visible text for context without breaking voice control.

---
*PR created automatically by Jules for task [13062802346592406912](https://jules.google.com/task/13062802346592406912) started by @Ganngann*