### PR TITLE
⚡ Bolt: Fix N+1 query issue inside ItemController image loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -2,3 +2,7 @@
 **Learning:** Checking `Auth::user()->unreadNotifications->count()` inside the navigation layout triggers an N+1 query issue since notifications might not be loaded, and `count()` triggers a separate count query on the relation each time it's called (or loads all notifications). Actually, it loads the relation because it uses the property `unreadNotifications` and then calls `count()` on the collection. In this case, `unreadNotifications()->count()` is much more efficient as it performs an aggregate query, but even better is doing it right in a View Composer if needed, or just `unreadNotifications()->count()`. Wait, since it's `Auth::user()->unreadNotifications->count()`, it loads ALL unread notifications into memory just to count them!
 
 **Action:** Replace `$user->unreadNotifications->count()` with `$user->unreadNotifications()->count()`. This executes a simple `COUNT(*)` query without fetching the actual model records.
+
+## 2024-05-16 - [N+1 query inside loop in ItemController]
+**Learning:** Calling `$item->images()->count()` inside a foreach loop executes a `SELECT COUNT(*)` query on the database during every single iteration.
+**Action:** Always cache the result of relationship aggregates like `count()` outside the loop and increment the cached variable internally to prevent N+1 query performance issues.

--- a/pifpaf/app/Http/Controllers/ItemController.php
+++ b/pifpaf/app/Http/Controllers/ItemController.php
@@ -406,9 +406,12 @@ class ItemController extends Controller
             // On récupère le dernier ordre pour continuer la séquence
             $order = $item->images()->max('order') + 1;
 
+            // Performance Optimization: Cache image count before loop to prevent N+1 query issue
+            $imageCount = $item->images()->count();
+
             foreach ($request->file('images') as $imageFile) {
                 // On vérifie qu'on ne dépasse pas la limite totale de 10 images
-                if ($item->images()->count() >= 10) {
+                if ($imageCount >= 10) {
                     break;
                 }
 
@@ -417,6 +420,7 @@ class ItemController extends Controller
                     'path' => $path,
                     'order' => $order++,
                 ]);
+                $imageCount++;
             }
         }
 


### PR DESCRIPTION
**What:**
Cached the relationship count calculation (`$item->images()->count()`) outside of the `foreach` image upload loop in `ItemController::update` and manually incremented it internally.

**Why:**
Calling a relationship aggregate method like `count()` inside a loop executes a new `SELECT COUNT(*)` query against the database on every single iteration. If a user uploaded 10 images, 10 redundant queries were executed. 

**Impact:**
Eliminates up to N redundant database queries per update request, where N is the number of uploaded images.

**Measurement:**
Run `php artisan test` to ensure all functionality remains exactly the same while avoiding redundant queries. The optimization has been verified locally.

---
*PR created automatically by Jules for task [17803774580366793891](https://jules.google.com/task/17803774580366793891) started by @Ganngann*