### PR TITLE
🎨 Palette: Improve empty state UX for AI analyses

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-30 - Empty States CTA duplication prevention
+**Learning:** When replacing plain `<p>` empty states with the styling-heavy `x-ui.empty-state` component and embedding a call-to-action (CTA) button within it, the UI can become confusing if a general, top-level "Create" or "Add" button remains visible simultaneously.
+**Action:** When implementing an empty state CTA, conditionally wrap any general page-level action buttons (e.g., using `@if($collection->isNotEmpty())`) to hide them when the empty state is displayed, ensuring a single, clear path forward for the user.

--- a/pifpaf/resources/views/ai-requests/index.blade.php
+++ b/pifpaf/resources/views/ai-requests/index.blade.php
@@ -14,11 +14,13 @@
                     <!-- Validation Errors -->
                     <x-auth-validation-errors class="mb-4" :errors="$errors" />
 
-                    <div class="mb-4">
-                        <a href="{{ route('items.create-with-ai') }}" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">
-                            {{ __('Lancer une nouvelle analyse') }}
-                        </a>
-                    </div>
+                    @if($requests->isNotEmpty())
+                        <div class="mb-4">
+                            <a href="{{ route('items.create-with-ai') }}" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">
+                                {{ __('Lancer une nouvelle analyse') }}
+                            </a>
+                        </div>
+                    @endif
 
                     @forelse ($requests as $request)
                         <div class="mb-6 p-4 border rounded-lg shadow-sm" x-data="{ open: false }" dusk="ai-request-{{ $request->id }}">
@@ -243,7 +245,14 @@
                             </div>
                         </div>
                     @empty
-                        <p>Vous n'avez aucune analyse IA pour le moment.</p>
+                        <x-ui.empty-state>
+                            Vous n'avez aucune analyse IA pour le moment.
+                            <x-slot name="actions">
+                                <a href="{{ route('items.create-with-ai') }}" class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 active:bg-gray-900 focus:outline-none focus:border-gray-900 focus:ring ring-gray-300 disabled:opacity-25 transition ease-in-out duration-150">
+                                    {{ __('Lancer une nouvelle analyse') }}
+                                </a>
+                            </x-slot>
+                        </x-ui.empty-state>
                     @endforelse
                 </div>
             </div>


### PR DESCRIPTION
Replaced the unstyled `<p>` element with the `x-ui.empty-state` component on the AI Requests index page when the list is empty. Added a Call-To-Action (CTA) inside the empty state pointing to the creation route to guide the user. Additionally, wrapped the top-level \"Lancer une nouvelle analyse\" button in an `@if($requests->isNotEmpty())` check to hide it when the empty state is displayed, preventing duplicate and confusing CTAs.

---
*PR created automatically by Jules for task [3073750457143094089](https://jules.google.com/task/3073750457143094089) started by @Ganngann*