### PR TITLE
⚡ Bolt: [Optimize N+1 query in Item image upload]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -2,3 +2,7 @@
 **Learning:** Checking `Auth::user()->unreadNotifications->count()` inside the navigation layout triggers an N+1 query issue since notifications might not be loaded, and `count()` triggers a separate count query on the relation each time it's called (or loads all notifications). Actually, it loads the relation because it uses the property `unreadNotifications` and then calls `count()` on the collection. In this case, `unreadNotifications()->count()` is much more efficient as it performs an aggregate query, but even better is doing it right in a View Composer if needed, or just `unreadNotifications()->count()`. Wait, since it's `Auth::user()->unreadNotifications->count()`, it loads ALL unread notifications into memory just to count them!
 
 **Action:** Replace `$user->unreadNotifications->count()` with `$user->unreadNotifications()->count()`. This executes a simple `COUNT(*)` query without fetching the actual model records.
+
+## 2026-06-01 - [N+1 query in image upload loop]
+**Learning:** Calling `$item->images()->count()` inside a loop iterates over the file upload array, which triggers a separate COUNT database query for each uploaded image. This can cause significant N+1 issues when uploading many files.
+**Action:** Always cache the aggregate result before the loop (e.g. `$currentImageCount = $item->images()->count();`) and increment it manually inside the loop.

--- a/pifpaf/app/Http/Controllers/ItemController.php
+++ b/pifpaf/app/Http/Controllers/ItemController.php
@@ -406,9 +406,12 @@ class ItemController extends Controller
             // On récupère le dernier ordre pour continuer la séquence
             $order = $item->images()->max('order') + 1;
 
+            // ⚡ Bolt: Cache initial image count to prevent N+1 queries in the loop
+            $currentImageCount = $item->images()->count();
+
             foreach ($request->file('images') as $imageFile) {
                 // On vérifie qu'on ne dépasse pas la limite totale de 10 images
-                if ($item->images()->count() >= 10) {
+                if ($currentImageCount >= 10) {
                     break;
                 }
 
@@ -417,6 +420,8 @@ class ItemController extends Controller
                     'path' => $path,
                     'order' => $order++,
                 ]);
+
+                $currentImageCount++;
             }
         }
 


### PR DESCRIPTION
💡 **What:** Cached the `$item->images()->count()` result outside the image upload `foreach` loop and incremented it manually.
🎯 **Why:** To eliminate an N+1 query issue where a separate `COUNT(*)` database query was executed for every single uploaded image inside the loop.
📊 **Impact:** Reduces database queries by up to 10 queries per image upload request, significantly improving the performance of the item update endpoint, especially when uploading multiple images.
🔬 **Measurement:** Verify the reduction in executed queries by checking the Laravel Telescope or query log during a bulk image upload (e.g., uploading 10 images at once).

---
*PR created automatically by Jules for task [2131346713972176050](https://jules.google.com/task/2131346713972176050) started by @Ganngann*