### PR TITLE
🎨 Palette: Improve purchases empty state

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-05-16 - Add ARIA Labels to Navigation Elements
 **Learning:** Icon-only links and toggle buttons (like the notifications bell and hamburger menu) are common in Laravel Breeze/Alpine navigation components but often lack accessible labels by default.
 **Action:** When adding or reviewing icon-only interactive elements, ensure `aria-label` is present. For elements that toggle state (like dropdowns or mobile menus), bind `aria-expanded` to the state variable (e.g., `:aria-expanded="open.toString()"` in Alpine.js) to communicate state to screen readers.
+
+## 2026-05-17 - Empty State Actions Pattern
+**Learning:** The `<x-primary-button>` Blade component only renders a `<button>` element and does not support an `href` attribute, requiring custom styling for links that act as Call-to-Actions in empty states.
+**Action:** When adding CTAs to empty states (like the `x-ui.empty-state` component), use standard Tailwind primary button classes on an `<a>` tag to maintain visual consistency without breaking semantic HTML.

--- a/pifpaf/resources/views/transactions/purchases.blade.php
+++ b/pifpaf/resources/views/transactions/purchases.blade.php
@@ -12,7 +12,22 @@
                     @forelse ($purchases as $transaction)
                         <x-purchase-card :transaction="$transaction" />
                     @empty
-                        <p>Vous n'avez effectué aucun achat pour le moment.</p>
+                        <x-ui.empty-state>
+                            <x-slot name="icon">
+                                <svg class="w-12 h-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 11V7a4 4 0 00-8 0v4M5 9h14l1 12H4L5 9z" />
+                                </svg>
+                            </x-slot>
+                            <x-slot name="description">
+                                Vous n'avez effectué aucun achat pour le moment.
+                            </x-slot>
+                            Aucun achat
+                            <x-slot name="actions">
+                                <a href="{{ route('welcome') }}" class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 active:bg-gray-900 focus:outline-none focus:border-gray-900 focus:ring ring-gray-300 disabled:opacity-25 transition ease-in-out duration-150">
+                                    Découvrir les articles
+                                </a>
+                            </x-slot>
+                        </x-ui.empty-state>
                     @endforelse
 
                     @if ($purchases->hasPages())


### PR DESCRIPTION
**What:**
Replaced the basic text "Vous n'avez effectué aucun achat pour le moment." on the `/purchases` page with the standard `x-ui.empty-state` Blade component. This adds an icon, a descriptive title, and a call-to-action button linking back to the welcome page to browse items.

**Why:**
To improve the user experience by providing a consistent, visually pleasing empty state and offering a clear next step (browsing items) instead of leaving the user at a dead end.

**Visuals:**
Before: Plain text.
After: Structured empty state component with icon and CTA.

**Accessibility:**
The CTA remains a semantic `<a>` tag with button styling, ensuring proper navigation behavior and keyboard accessibility. Added a journal entry in `.Jules/palette.md` to document this pattern.

---
*PR created automatically by Jules for task [6374720799882613822](https://jules.google.com/task/6374720799882613822) started by @Ganngann*