### PR TITLE
⚡ Bolt: Fix N+1 query in item image upload loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -2,3 +2,7 @@
 **Learning:** Checking `Auth::user()->unreadNotifications->count()` inside the navigation layout triggers an N+1 query issue since notifications might not be loaded, and `count()` triggers a separate count query on the relation each time it's called (or loads all notifications). Actually, it loads the relation because it uses the property `unreadNotifications` and then calls `count()` on the collection. In this case, `unreadNotifications()->count()` is much more efficient as it performs an aggregate query, but even better is doing it right in a View Composer if needed, or just `unreadNotifications()->count()`. Wait, since it's `Auth::user()->unreadNotifications->count()`, it loads ALL unread notifications into memory just to count them!
 
 **Action:** Replace `$user->unreadNotifications->count()` with `$user->unreadNotifications()->count()`. This executes a simple `COUNT(*)` query without fetching the actual model records.
+
+## 2026-06-05 - [N+1 query in loops]
+**Learning:** Calling relationship aggregates like `$item->images()->count()` inside a loop (e.g. while processing multiple file uploads) executes a new `SELECT COUNT(*)` SQL query on each iteration, causing an N+1 performance bottleneck.
+**Action:** Always cache the aggregate result in a variable before entering the loop (e.g., `$currentImageCount = $item->images()->count();`) and manually increment it inside the loop to avoid redundant database calls.

--- a/pifpaf/app/Http/Controllers/ItemController.php
+++ b/pifpaf/app/Http/Controllers/ItemController.php
@@ -406,9 +406,12 @@ class ItemController extends Controller
             // On récupère le dernier ordre pour continuer la séquence
             $order = $item->images()->max('order') + 1;
 
+            // ⚡ Bolt: Cache image count before loop to prevent N+1 query performance issues
+            $currentImageCount = $item->images()->count();
+
             foreach ($request->file('images') as $imageFile) {
                 // On vérifie qu'on ne dépasse pas la limite totale de 10 images
-                if ($item->images()->count() >= 10) {
+                if ($currentImageCount >= 10) {
                     break;
                 }
 
@@ -417,6 +420,8 @@ class ItemController extends Controller
                     'path' => $path,
                     'order' => $order++,
                 ]);
+
+                $currentImageCount++;
             }
         }
 


### PR DESCRIPTION
💡 What: Cached `$item->images()->count()` into a local variable before looping through uploaded files.
🎯 Why: In `ItemController.php`, calling `$item->images()->count()` inside a `foreach` loop triggers a `SELECT COUNT(*)` database query on each iteration, causing an N+1 performance bottleneck when an item has many images or when a user uploads multiple images simultaneously.
📊 Impact: Eliminates N+1 query overhead. Instead of executing up to 10 queries, only 1 query is executed.
🔬 Measurement: Verified via unit test suite execution without any regressions.

---
*PR created automatically by Jules for task [11718780867763777725](https://jules.google.com/task/11718780867763777725) started by @Ganngann*