### PR TITLE
🎨 Palette: Improve empty state for user addresses

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-05-16 - Add ARIA Labels to Navigation Elements
 **Learning:** Icon-only links and toggle buttons (like the notifications bell and hamburger menu) are common in Laravel Breeze/Alpine navigation components but often lack accessible labels by default.
 **Action:** When adding or reviewing icon-only interactive elements, ensure `aria-label` is present. For elements that toggle state (like dropdowns or mobile menus), bind `aria-expanded` to the state variable (e.g., `:aria-expanded="open.toString()"` in Alpine.js) to communicate state to screen readers.
+
+## 2025-06-05 - Profile Addresses Empty State UX
+**Learning:** Replaced an unstyled plain text empty state ("Vous n'avez pas encore d'adresse enregistrée.") with the existing `x-ui.empty-state` component and a clear Call-To-Action. Found that if we add a CTA to the empty state, it creates confusing duplicate actions if the top-level "Add" button isn't conditionally hidden.
+**Action:** When creating empty states using the dedicated Blade component and adding CTAs inside them, always ensure top-level buttons serving the same action are hidden when the list is empty to prevent UI clutter and confusion.

--- a/pifpaf/resources/views/profile/addresses/index.blade.php
+++ b/pifpaf/resources/views/profile/addresses/index.blade.php
@@ -11,12 +11,29 @@
                 <div class="p-6 bg-white border-b border-gray-200">
                     <div class="flex justify-between items-center mb-4">
                         <h3 class="text-lg font-semibold">Toutes mes adresses</h3>
-                        <a href="{{ route('profile.addresses.create') }}" class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 active:bg-gray-900 focus:outline-none focus:border-gray-900 focus:ring ring-gray-300 disabled:opacity-25 transition ease-in-out duration-150">
-                            Ajouter une adresse
-                        </a>
+                        @if($addresses->isNotEmpty())
+                            <a href="{{ route('profile.addresses.create') }}" class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 active:bg-gray-900 focus:outline-none focus:border-gray-900 focus:ring ring-gray-300 disabled:opacity-25 transition ease-in-out duration-150">
+                                Ajouter une adresse
+                            </a>
+                        @endif
                     </div>
                     @if($addresses->isEmpty())
-                        <p>Vous n'avez pas encore d'adresse enregistrée.</p>
+                        <x-ui.empty-state>
+                            Vous n'avez pas encore d'adresse enregistrée.
+
+                            <x-slot name="icon">
+                                <svg class="h-12 w-12 text-gray-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
+                                </svg>
+                            </x-slot>
+
+                            <x-slot name="actions">
+                                <a href="{{ route('profile.addresses.create') }}" class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 active:bg-gray-900 focus:outline-none focus:border-gray-900 focus:ring ring-gray-300 disabled:opacity-25 transition ease-in-out duration-150">
+                                    Ajouter une adresse
+                                </a>
+                            </x-slot>
+                        </x-ui.empty-state>
                     @else
                         <div class="space-y-4">
                             @foreach($addresses as $address)


### PR DESCRIPTION
Replaced the unstyled plain text empty state ("Vous n'avez pas encore d'adresse enregistrée.") with the `x-ui.empty-state` component. The new empty state includes an appropriate SVG icon and directly integrates the "Ajouter une adresse" call-to-action button within the empty state itself. To prevent UI clutter and confusing duplicate actions, the top-level "Ajouter une adresse" button is now conditionally hidden when the address list is empty.

---
*PR created automatically by Jules for task [1223849371984052462](https://jules.google.com/task/1223849371984052462) started by @Ganngann*