### PR TITLE
⚡ Bolt: Fix N+1 query when updating item images

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -2,3 +2,7 @@
 **Learning:** Checking `Auth::user()->unreadNotifications->count()` inside the navigation layout triggers an N+1 query issue since notifications might not be loaded, and `count()` triggers a separate count query on the relation each time it's called (or loads all notifications). Actually, it loads the relation because it uses the property `unreadNotifications` and then calls `count()` on the collection. In this case, `unreadNotifications()->count()` is much more efficient as it performs an aggregate query, but even better is doing it right in a View Composer if needed, or just `unreadNotifications()->count()`. Wait, since it's `Auth::user()->unreadNotifications->count()`, it loads ALL unread notifications into memory just to count them!
 
 **Action:** Replace `$user->unreadNotifications->count()` with `$user->unreadNotifications()->count()`. This executes a simple `COUNT(*)` query without fetching the actual model records.
+
+## 2024-06-06 - N+1 Query in Loops
+**Learning:** Calling relationship aggregate methods like `->count()` inside loops triggers a new database query on each iteration. In `app/Http/Controllers/ItemController.php`, this resulted in an N+1 query issue when checking the image limit for each uploaded image.
+**Action:** Always cache the aggregate result (e.g., `->count()`) before the loop and manually increment the cached value inside the loop to prevent N+1 query performance issues.

--- a/pifpaf/app/Http/Controllers/ItemController.php
+++ b/pifpaf/app/Http/Controllers/ItemController.php
@@ -405,10 +405,12 @@ class ItemController extends Controller
         if ($request->hasFile('images')) {
             // On récupère le dernier ordre pour continuer la séquence
             $order = $item->images()->max('order') + 1;
+            // ⚡ Bolt: Cache image count before the loop to prevent N+1 queries when adding multiple images
+            $currentImageCount = $item->images()->count();
 
             foreach ($request->file('images') as $imageFile) {
                 // On vérifie qu'on ne dépasse pas la limite totale de 10 images
-                if ($item->images()->count() >= 10) {
+                if ($currentImageCount >= 10) {
                     break;
                 }
 
@@ -417,6 +419,8 @@ class ItemController extends Controller
                     'path' => $path,
                     'order' => $order++,
                 ]);
+
+                $currentImageCount++;
             }
         }
 


### PR DESCRIPTION
💡 What: The optimization implemented
Moved the `$item->images()->count()` check outside the image upload loop in `app/Http/Controllers/ItemController.php` and manually incremented the cached variable.
    
🎯 Why: The performance problem it solves
In Laravel, calling a relationship aggregate method like `->count()` triggers a new database query. Inside a loop that iterates over multiple uploaded images, this resulted in an N+1 query issue where the database was queried again for each image uploaded, just to check if the limit of 10 was reached.

📊 Impact: Expected performance improvement
Eliminates up to 10 redundant `SELECT COUNT(*)` database queries per multi-image upload request, saving database load and slightly improving the response time for the update request.

🔬 Measurement: How to verify the improvement
Upload multiple images while editing an item and monitor query logs or application performance tools to verify that only a single count query is executed.

---
*PR created automatically by Jules for task [10704759237892436769](https://jules.google.com/task/10704759237892436769) started by @Ganngann*