### PR TITLE
🛡️ Sentinel: [HIGH] Fix race condition double-crediting vulnerability in dispute resolution

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,7 @@
 **Vulnerability:** The application had a critical path traversal vulnerability in `AiRequestController.php` and `ItemController.php` where user-controlled input (`image_path`, `original_image_path`) was passed directly to `Storage::disk('public')->path()` and `Storage::disk('public')->move()` without proper sanitization. This allowed attackers to potentially read or move arbitrary files on the server using `../../` sequences.
 **Learning:** Even when using Laravel's storage facade, unsanitized user input passed to methods like `path()`, `exists()`, or `move()` is unsafe. Path parameters received from external requests must be strictly validated.
 **Prevention:** Always validate file paths from external input using strict regex constraints (e.g., `regex:/^ai_images\/[a-zA-Z0-9_\-\.]+$/`) to ensure they only point to expected directories and do not contain directory traversal sequences.
+## 2024-06-06 - Prevent Double Processing in Admin Actions
+**Vulnerability:** Race condition / Replay attack risk in dispute resolution (financial transaction) methods.
+**Learning:** `AdminController` methods `resolveForBuyer`, `resolveForSeller`, and `closeDispute` processed financial transactions without checking if the dispute was already resolved (`status !== 'open'`), which could lead to double-crediting if a user double-clicks or via a race condition.
+**Prevention:** Always check the entity state (`if ($entity->status !== 'expected_status')`) at the top of controller methods that perform critical state changes or financial transactions.

--- a/pifpaf/app/Http/Controllers/AdminController.php
+++ b/pifpaf/app/Http/Controllers/AdminController.php
@@ -169,6 +169,11 @@ class AdminController extends Controller
      */
     public function resolveForBuyer(Dispute $dispute)
     {
+        // 🛡️ Sentinel: Prevent double-crediting if dispute is already closed
+        if ($dispute->status !== 'open') {
+            return redirect()->route('admin.disputes.index')->with('error', 'Ce litige a déjà été traité.');
+        }
+
         $transaction = $dispute->transaction;
         $buyer = $transaction->offer->user;
 
@@ -191,6 +196,11 @@ class AdminController extends Controller
      */
     public function resolveForSeller(Dispute $dispute)
     {
+        // 🛡️ Sentinel: Prevent double-crediting if dispute is already closed
+        if ($dispute->status !== 'open') {
+            return redirect()->route('admin.disputes.index')->with('error', 'Ce litige a déjà été traité.');
+        }
+
         $transaction = $dispute->transaction;
         $seller = $transaction->offer->item->user;
 
@@ -213,6 +223,11 @@ class AdminController extends Controller
      */
     public function closeDispute(Dispute $dispute)
     {
+        // 🛡️ Sentinel: Prevent processing if dispute is already closed
+        if ($dispute->status !== 'open') {
+            return redirect()->route('admin.disputes.index')->with('error', 'Ce litige a déjà été traité.');
+        }
+
         $dispute->update(['status' => 'closed']);
         return redirect()->route('admin.disputes.index')->with('success', 'Le litige a été clôturé.');
     }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Race condition/Replay attack in `AdminController`. The methods `resolveForBuyer`, `resolveForSeller`, and `closeDispute` did not verify the dispute's current status before executing.
🎯 **Impact:** If an admin accidentally double-clicked the resolution button, or an attacker exploited a race condition, the buyer/seller's wallet could be double-credited for the same transaction amount.
🔧 **Fix:** Added a state check (`if ($dispute->status !== 'open')`) at the beginning of each relevant method. If the dispute is already closed, it immediately redirects back with an error message.
✅ **Verification:** Verified via `php artisan test` (all 226 tests pass). The patch modifies logic entirely in PHP and does not affect the frontend UI. Tests explicitly covering `AdminDisputesTest` pass successfully.

---
*PR created automatically by Jules for task [10522491598137050253](https://jules.google.com/task/10522491598137050253) started by @Ganngann*