### PR TITLE
⚡ Bolt: Remove N+1 query when updating item images

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -2,3 +2,7 @@
 **Learning:** Checking `Auth::user()->unreadNotifications->count()` inside the navigation layout triggers an N+1 query issue since notifications might not be loaded, and `count()` triggers a separate count query on the relation each time it's called (or loads all notifications). Actually, it loads the relation because it uses the property `unreadNotifications` and then calls `count()` on the collection. In this case, `unreadNotifications()->count()` is much more efficient as it performs an aggregate query, but even better is doing it right in a View Composer if needed, or just `unreadNotifications()->count()`. Wait, since it's `Auth::user()->unreadNotifications->count()`, it loads ALL unread notifications into memory just to count them!
 
 **Action:** Replace `$user->unreadNotifications->count()` with `$user->unreadNotifications()->count()`. This executes a simple `COUNT(*)` query without fetching the actual model records.
+
+## 2024-05-18 - [N+1 query during image upload update]
+**Learning:** Checking `$item->images()->count()` inside a `foreach` loop when adding new images triggers an N+1 query issue since it executes a `COUNT()` SQL query against the database for every single image uploaded in the loop.
+**Action:** Extract `$item->images()->count()` to a variable `$currentImageCount` before the loop. Inside the loop, check against this variable and increment it manually after each successfully added image.

--- a/pifpaf/app/Http/Controllers/ItemController.php
+++ b/pifpaf/app/Http/Controllers/ItemController.php
@@ -406,9 +406,12 @@ class ItemController extends Controller
             // On récupère le dernier ordre pour continuer la séquence
             $order = $item->images()->max('order') + 1;
 
+            // On compte les images une seule fois avant la boucle pour éviter une requête N+1
+            $currentImageCount = $item->images()->count();
+
             foreach ($request->file('images') as $imageFile) {
                 // On vérifie qu'on ne dépasse pas la limite totale de 10 images
-                if ($item->images()->count() >= 10) {
+                if ($currentImageCount >= 10) {
                     break;
                 }
 
@@ -417,6 +420,7 @@ class ItemController extends Controller
                     'path' => $path,
                     'order' => $order++,
                 ]);
+                $currentImageCount++;
             }
         }
 


### PR DESCRIPTION
💡 What: Extracted the `$item->images()->count()` query to a variable before the `foreach` loop inside `ItemController@update`.
🎯 Why: Calling `count()` on the Eloquent relation inside the loop triggered a separate database query for each uploaded image, resulting in an N+1 performance bottleneck.
📊 Impact: Reduces database queries from N+1 (where N is the number of uploaded images) to 1.
🔬 Measurement: Verified via `php artisan test` and reviewing the modified code logic to confirm the loop now relies on a local incrementing counter variable instead of hitting the database.

---
*PR created automatically by Jules for task [11584378292934186072](https://jules.google.com/task/11584378292934186072) started by @Ganngann*