### PR TITLE
⚡ Bolt: Fix N+1 query issue during image upload in ItemController

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -2,3 +2,7 @@
 **Learning:** Checking `Auth::user()->unreadNotifications->count()` inside the navigation layout triggers an N+1 query issue since notifications might not be loaded, and `count()` triggers a separate count query on the relation each time it's called (or loads all notifications). Actually, it loads the relation because it uses the property `unreadNotifications` and then calls `count()` on the collection. In this case, `unreadNotifications()->count()` is much more efficient as it performs an aggregate query, but even better is doing it right in a View Composer if needed, or just `unreadNotifications()->count()`. Wait, since it's `Auth::user()->unreadNotifications->count()`, it loads ALL unread notifications into memory just to count them!
 
 **Action:** Replace `$user->unreadNotifications->count()` with `$user->unreadNotifications()->count()`. This executes a simple `COUNT(*)` query without fetching the actual model records.
+
+## 2024-05-24 - [N+1 query in image upload loop]
+**Learning:** Using `$item->images()->count()` inside a `foreach` loop that uploads multiple images triggers an N+1 query issue. Because `count()` is a relationship aggregate method, it executes a separate `SELECT COUNT(*)` database query on every iteration, severely hurting performance during multi-file uploads.
+**Action:** Extract the aggregate method call to cache its value before the loop begins (e.g., `$currentImageCount = $item->images()->count();`), and then manually manage the variable (e.g., `$currentImageCount++`) inside the loop to avoid redundant database calls.

--- a/pifpaf/app/Http/Controllers/ItemController.php
+++ b/pifpaf/app/Http/Controllers/ItemController.php
@@ -406,9 +406,12 @@ class ItemController extends Controller
             // On récupère le dernier ordre pour continuer la séquence
             $order = $item->images()->max('order') + 1;
 
+            // ⚡ Bolt: Cache image count before loop to prevent N+1 queries during upload
+            $currentImageCount = $item->images()->count();
+
             foreach ($request->file('images') as $imageFile) {
                 // On vérifie qu'on ne dépasse pas la limite totale de 10 images
-                if ($item->images()->count() >= 10) {
+                if ($currentImageCount >= 10) {
                     break;
                 }
 
@@ -417,6 +420,7 @@ class ItemController extends Controller
                     'path' => $path,
                     'order' => $order++,
                 ]);
+                $currentImageCount++;
             }
         }
 


### PR DESCRIPTION
* 💡 What: Cached the image count before the loop to avoid calling `count()` in each iteration during image uploads in `ItemController@update`.
* 🎯 Why: To solve an N+1 query problem where checking the image count triggered a separate database `COUNT` query for every image uploaded.
* 📊 Impact: Eliminates redundant database queries during multiple image uploads, reducing the number of queries and speeding up the upload process.
* 🔬 Measurement: Observe database queries (e.g., via Telescope or QueryLog) during image uploads to verify that only one `COUNT` query is executed.

---
*PR created automatically by Jules for task [4154082816329478673](https://jules.google.com/task/4154082816329478673) started by @Ganngann*