### PR TITLE
⚡ Bolt: Fix N+1 query in item image upload loop

### DIFF
--- a/pifpaf/.jules/bolt.md
+++ b/pifpaf/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-06-09 - N+1 query via aggregate functions in loops
+**Learning:** Calling an aggregate function like `->count()` on a relationship (e.g. `$model->relation()->count()`) inside a loop triggers a new database query on each iteration, causing N+1 query performance issues.
+**Action:** Always cache the aggregate result before the loop and track it locally inside the loop to avoid redundant database queries.

--- a/pifpaf/app/Http/Controllers/ItemController.php
+++ b/pifpaf/app/Http/Controllers/ItemController.php
@@ -406,9 +406,12 @@ class ItemController extends Controller
             // On récupère le dernier ordre pour continuer la séquence
             $order = $item->images()->max('order') + 1;
 
+            // Cache the image count to prevent N+1 query inside the loop
+            $imageCount = $item->images()->count();
+
             foreach ($request->file('images') as $imageFile) {
                 // On vérifie qu'on ne dépasse pas la limite totale de 10 images
-                if ($item->images()->count() >= 10) {
+                if ($imageCount >= 10) {
                     break;
                 }
 
@@ -417,6 +420,9 @@ class ItemController extends Controller
                     'path' => $path,
                     'order' => $order++,
                 ]);
+
+                // Increment the local image count after creating a new image
+                $imageCount++;
             }
         }
 


### PR DESCRIPTION
💡 **What:** Caches `$item->images()->count()` into a local variable before a `foreach` loop in `ItemController@update`, and increments the local variable manually inside the loop.
🎯 **Why:** Calling `->count()` on a relationship inside a loop executes a new `SELECT COUNT(*)` database query on every iteration, leading to an N+1 query issue which severely degrades performance when uploading multiple images.
📊 **Impact:** Reduces database queries by O(n) during item image uploads, saving one query per uploaded image.
🔬 **Measurement:** Verify by running the test suite (`php artisan test`) and ensuring all tests (specifically `ItemControllerTest` and `ItemPublicationTest`) pass as before.

---
*PR created automatically by Jules for task [715616695514068443](https://jules.google.com/task/715616695514068443) started by @Ganngann*