### PR TITLE
🎨 Palette: Improve empty state for user addresses

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-05-16 - Add ARIA Labels to Navigation Elements
 **Learning:** Icon-only links and toggle buttons (like the notifications bell and hamburger menu) are common in Laravel Breeze/Alpine navigation components but often lack accessible labels by default.
 **Action:** When adding or reviewing icon-only interactive elements, ensure `aria-label` is present. For elements that toggle state (like dropdowns or mobile menus), bind `aria-expanded` to the state variable (e.g., `:aria-expanded="open.toString()"` in Alpine.js) to communicate state to screen readers.
+
+## 2026-05-16 - Add Empty States with Helpful CTAs
+**Learning:** When displaying an empty list (like addresses, purchases, or sales), replacing unstyled `<p>` tags with a consistent `<x-ui.empty-state>` component improves visual consistency. Furthermore, it is a crucial UX pattern to *always* provide a relevant Call-to-Action (CTA) inside the empty state so users know immediately how to resolve the empty state.
+**Action:** Always include a CTA link (e.g., using primary button styling) inside the `<x-slot name="actions">` of the `<x-ui.empty-state>` component. Conditionally hide redundant top-level action buttons when the list is empty to avoid duplicating the CTA.

--- a/pifpaf/resources/views/profile/addresses/index.blade.php
+++ b/pifpaf/resources/views/profile/addresses/index.blade.php
@@ -11,12 +11,21 @@
                 <div class="p-6 bg-white border-b border-gray-200">
                     <div class="flex justify-between items-center mb-4">
                         <h3 class="text-lg font-semibold">Toutes mes adresses</h3>
-                        <a href="{{ route('profile.addresses.create') }}" class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 active:bg-gray-900 focus:outline-none focus:border-gray-900 focus:ring ring-gray-300 disabled:opacity-25 transition ease-in-out duration-150">
-                            Ajouter une adresse
-                        </a>
+                        @if($addresses->isNotEmpty())
+                            <a href="{{ route('profile.addresses.create') }}" class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 active:bg-gray-900 focus:outline-none focus:border-gray-900 focus:ring ring-gray-300 disabled:opacity-25 transition ease-in-out duration-150">
+                                Ajouter une adresse
+                            </a>
+                        @endif
                     </div>
                     @if($addresses->isEmpty())
-                        <p>Vous n'avez pas encore d'adresse enregistrée.</p>
+                        <x-ui.empty-state>
+                            Vous n'avez pas encore d'adresse enregistrée.
+                            <x-slot name="actions">
+                                <a href="{{ route('profile.addresses.create') }}" class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 active:bg-gray-900 focus:outline-none focus:border-gray-900 focus:ring ring-gray-300 disabled:opacity-25 transition ease-in-out duration-150">
+                                    Ajouter une adresse
+                                </a>
+                            </x-slot>
+                        </x-ui.empty-state>
                     @else
                         <div class="space-y-4">
                             @foreach($addresses as $address)


### PR DESCRIPTION
💡 **What:** Replaced the plain text empty state on the addresses page with the `x-ui.empty-state` component and added a prominent call-to-action.
🎯 **Why:** To provide a clearer, more visually appealing empty state that guides users on exactly what to do next when they have no addresses configured.
📸 **Before/After:** The plain text `<p>` tag is now a nicely styled dashed box with a primary button to add an address. The redundant top button is hidden when empty.
♿ **Accessibility:** Provides clear focus and direction for the user instead of a passive text message.

---
*PR created automatically by Jules for task [8607925821330771177](https://jules.google.com/task/8607925821330771177) started by @Ganngann*