### PR TITLE
⚡ Bolt: Fix N+1 query in item image upload

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -2,3 +2,7 @@
 **Learning:** Checking `Auth::user()->unreadNotifications->count()` inside the navigation layout triggers an N+1 query issue since notifications might not be loaded, and `count()` triggers a separate count query on the relation each time it's called (or loads all notifications). Actually, it loads the relation because it uses the property `unreadNotifications` and then calls `count()` on the collection. In this case, `unreadNotifications()->count()` is much more efficient as it performs an aggregate query, but even better is doing it right in a View Composer if needed, or just `unreadNotifications()->count()`. Wait, since it's `Auth::user()->unreadNotifications->count()`, it loads ALL unread notifications into memory just to count them!
 
 **Action:** Replace `$user->unreadNotifications->count()` with `$user->unreadNotifications()->count()`. This executes a simple `COUNT(*)` query without fetching the actual model records.
+
+## 2024-05-17 - [N+1 Query Issue with Count in Loop]
+**Learning:** Calling `$item->images()->count()` on a related model from inside a `foreach` loop inside `ItemController.php` triggers an N+1 query issue since it generates a new aggregate query during each iteration.
+**Action:** When needing an aggregate count within a loop, cache the aggregate result outside the loop and maintain it manually (e.g. `$count++`) inside the loop.

--- a/pifpaf/app/Http/Controllers/ItemController.php
+++ b/pifpaf/app/Http/Controllers/ItemController.php
@@ -406,9 +406,12 @@ class ItemController extends Controller
             // On récupère le dernier ordre pour continuer la séquence
             $order = $item->images()->max('order') + 1;
 
+            // ⚡ Bolt: Cache image count before the loop to prevent an N+1 query issue on each iteration
+            $currentImageCount = $item->images()->count();
+
             foreach ($request->file('images') as $imageFile) {
                 // On vérifie qu'on ne dépasse pas la limite totale de 10 images
-                if ($item->images()->count() >= 10) {
+                if ($currentImageCount >= 10) {
                     break;
                 }
 
@@ -417,6 +420,7 @@ class ItemController extends Controller
                     'path' => $path,
                     'order' => $order++,
                 ]);
+                $currentImageCount++;
             }
         }
 


### PR DESCRIPTION
💡 What: Cached `$item->images()->count()` inside `ItemController.php` outside of the `foreach` loop.
🎯 Why: An N+1 query was executed on every loop iteration to retrieve the image count, which causes unnecessary load on the database.
📊 Impact: Reduces `COUNT` queries from up to 10 iterations down to 1 single query during image uploads.
🔬 Measurement: Verify this by observing the query log in Laravel Telescope or debugbar, or manually review the change in `pifpaf/app/Http/Controllers/ItemController.php` lines 405-420.

---
*PR created automatically by Jules for task [8732657692140352103](https://jules.google.com/task/8732657692140352103) started by @Ganngann*