### PR TITLE
🛡️ Sentinel: [HIGH] Fix IDOR in AI requests

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,7 @@
 **Vulnerability:** The application had a critical path traversal vulnerability in `AiRequestController.php` and `ItemController.php` where user-controlled input (`image_path`, `original_image_path`) was passed directly to `Storage::disk('public')->path()` and `Storage::disk('public')->move()` without proper sanitization. This allowed attackers to potentially read or move arbitrary files on the server using `../../` sequences.
 **Learning:** Even when using Laravel's storage facade, unsanitized user input passed to methods like `path()`, `exists()`, or `move()` is unsafe. Path parameters received from external requests must be strictly validated.
 **Prevention:** Always validate file paths from external input using strict regex constraints (e.g., `regex:/^ai_images\/[a-zA-Z0-9_\-\.]+$/`) to ensure they only point to expected directories and do not contain directory traversal sequences.
+## 2025-02-12 - Insecure Direct Object Reference via Secondary Identifiers
+**Vulnerability:** IDOR vulnerability when looking up resources via secondary identifiers (like image_path) without verifying model ownership.
+**Learning:** Always verify model ownership (e.g., user_id === Auth::id()) when retrieving models via secondary identifiers or file paths, such as querying by image_path.
+**Prevention:** Check Auth::id() against the model's user_id before returning or modifying data based on user input.

--- a/pifpaf/app/Http/Controllers/AiRequestController.php
+++ b/pifpaf/app/Http/Controllers/AiRequestController.php
@@ -60,6 +60,11 @@ class AiRequestController extends Controller
 
         $originalPath = $validated['image_path'];
 
+        $aiRequest = \App\Models\AiRequest::where('image_path', $originalPath)->first();
+        if (!$aiRequest || $aiRequest->user_id !== \Illuminate\Support\Facades\Auth::id()) {
+            return response('Accès non autorisé.', 403);
+        }
+
         if (!Storage::disk('public')->exists($originalPath)) {
             return response('Image not found.', 404);
         }

--- a/pifpaf/app/Http/Controllers/ItemController.php
+++ b/pifpaf/app/Http/Controllers/ItemController.php
@@ -218,6 +218,10 @@ class ItemController extends Controller
             return response()->json(['success' => false, 'message' => 'Requête IA non trouvée.']);
         }
 
+        if ($aiRequest->user_id !== \Illuminate\Support\Facades\Auth::id()) {
+            return response()->json(['success' => false, 'message' => 'Accès non autorisé.'], 403);
+        }
+
         if ($aiRequest->status !== 'completed') {
             return response()->json(['success' => false, 'message' => 'L\'analyse IA n\'est pas terminée.']);
         }

--- a/pifpaf/routes/web.php
+++ b/pifpaf/routes/web.php
@@ -102,9 +102,9 @@ Route::middleware('auth')->group(function () {
     // Routes pour les notifications
     Route::get('/notifications', [NotificationController::class, 'index'])->name('notifications.index');
     Route::patch('/notifications/{id}/read', [NotificationController::class, 'markAsRead'])->name('notifications.read');
-});
 
-Route::get('/ai-requests/crop-preview', [AiRequestController::class, 'cropPreview'])->name('ai.requests.crop_preview');
+    Route::get('/ai-requests/crop-preview', [AiRequestController::class, 'cropPreview'])->name('ai.requests.crop_preview');
+});
 
 Route::get('/items/{item}', [ItemController::class, 'show'])->name('items.show');
 Route::get('/profile/{user}', [ProfileController::class, 'show'])->name('profile.show');


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** IDOR and Authorization Bypass in `cropPreview` and `createFromAi`. Users could potentially crop or create items using other users' images by supplying their `image_path`. The route for `cropPreview` was completely unauthenticated.
🎯 **Impact:** Any user, authenticated or unauthenticated, could access and crop other users' AI images. Furthermore, authenticated users could create items from other users' AI request images if they guessed the path.
🔧 **Fix:** 
- Moved the `ai-requests/crop-preview` route inside the `auth` middleware group in `routes/web.php`.
- Added ownership checks (`user_id === Auth::id()`) in `AiRequestController::cropPreview` and `ItemController::createFromAi` before processing the files.
- Documented learning about verifying ownership for secondary identifiers in `.jules/sentinel.md`.
✅ **Verification:** Ran test suite to ensure the changes did not break the app (`php artisan test`). Manually inspected the codebase.

---
*PR created automatically by Jules for task [9254649628457777329](https://jules.google.com/task/9254649628457777329) started by @Ganngann*