### PR TITLE
⚡ Bolt: Cache image count to prevent N+1 queries during item update

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -2,3 +2,6 @@
 **Learning:** Checking `Auth::user()->unreadNotifications->count()` inside the navigation layout triggers an N+1 query issue since notifications might not be loaded, and `count()` triggers a separate count query on the relation each time it's called (or loads all notifications). Actually, it loads the relation because it uses the property `unreadNotifications` and then calls `count()` on the collection. In this case, `unreadNotifications()->count()` is much more efficient as it performs an aggregate query, but even better is doing it right in a View Composer if needed, or just `unreadNotifications()->count()`. Wait, since it's `Auth::user()->unreadNotifications->count()`, it loads ALL unread notifications into memory just to count them!
 
 **Action:** Replace `$user->unreadNotifications->count()` with `$user->unreadNotifications()->count()`. This executes a simple `COUNT(*)` query without fetching the actual model records.
+## 2024-05-23 - Cache aggregate counts before loops
+**Learning:** Calling relationship aggregate methods like ->count() inside a loop causes N+1 queries.
+**Action:** Always calculate and cache aggregate values before loops and increment the cached variable manually.

--- a/pifpaf/app/Http/Controllers/ItemController.php
+++ b/pifpaf/app/Http/Controllers/ItemController.php
@@ -406,9 +406,12 @@ class ItemController extends Controller
             // On récupère le dernier ordre pour continuer la séquence
             $order = $item->images()->max('order') + 1;
 
+            // Cache the image count to prevent N+1 database queries in the loop
+            $currentImageCount = $item->images()->count();
+
             foreach ($request->file('images') as $imageFile) {
                 // On vérifie qu'on ne dépasse pas la limite totale de 10 images
-                if ($item->images()->count() >= 10) {
+                if ($currentImageCount >= 10) {
                     break;
                 }
 
@@ -417,6 +420,8 @@ class ItemController extends Controller
                     'path' => $path,
                     'order' => $order++,
                 ]);
+
+                $currentImageCount++;
             }
         }
 


### PR DESCRIPTION
* 💡 What: Cached the image count in a variable before the upload loop in `ItemController@update`.
* 🎯 Why: The previous code called `$item->images()->count()` inside the `foreach` loop, executing a new database query for every uploaded image (N+1 query problem).
* 📊 Impact: Reduces database queries from O(N) to O(1) when uploading multiple images during item updates.
* 🔬 Measurement: Verify by checking Laravel Telescope, clockwork, or the query log when updating an item with multiple images to see that only one `COUNT` query is executed.

---
*PR created automatically by Jules for task [14660864156189179787](https://jules.google.com/task/14660864156189179787) started by @Ganngann*