### PR TITLE
⚡ Bolt: [performance improvement] Cache image count in loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -2,3 +2,7 @@
 **Learning:** Checking `Auth::user()->unreadNotifications->count()` inside the navigation layout triggers an N+1 query issue since notifications might not be loaded, and `count()` triggers a separate count query on the relation each time it's called (or loads all notifications). Actually, it loads the relation because it uses the property `unreadNotifications` and then calls `count()` on the collection. In this case, `unreadNotifications()->count()` is much more efficient as it performs an aggregate query, but even better is doing it right in a View Composer if needed, or just `unreadNotifications()->count()`. Wait, since it's `Auth::user()->unreadNotifications->count()`, it loads ALL unread notifications into memory just to count them!
 
 **Action:** Replace `$user->unreadNotifications->count()` with `$user->unreadNotifications()->count()`. This executes a simple `COUNT(*)` query without fetching the actual model records.
+
+## 2024-06-13 - [N+1 count query in loop]
+**Learning:** Calling an aggregate function like `->count()` on a relationship inside a loop triggers a new database query on every iteration, leading to an N+1 performance bottleneck.
+**Action:** Always cache the aggregate result before the loop and update the cached variable internally to prevent redundant queries.

--- a/pifpaf/app/Http/Controllers/ItemController.php
+++ b/pifpaf/app/Http/Controllers/ItemController.php
@@ -406,9 +406,12 @@ class ItemController extends Controller
             // On récupère le dernier ordre pour continuer la séquence
             $order = $item->images()->max('order') + 1;
 
+            // ⚡ Bolt: Cache image count outside the loop to prevent N+1 queries during iteration
+            $imageCount = $item->images()->count();
+
             foreach ($request->file('images') as $imageFile) {
                 // On vérifie qu'on ne dépasse pas la limite totale de 10 images
-                if ($item->images()->count() >= 10) {
+                if ($imageCount >= 10) {
                     break;
                 }
 
@@ -417,6 +420,7 @@ class ItemController extends Controller
                     'path' => $path,
                     'order' => $order++,
                 ]);
+                $imageCount++;
             }
         }
 


### PR DESCRIPTION
💡 What: Cached `$item->images()->count()` outside the `foreach` loop inside `ItemController@update` and manually incremented it internally.
🎯 Why: Avoids an N+1 query issue where the DB was queried to check the count on every image iteration upload.
📊 Impact: Saves N queries per update request involving multiple images. 
🔬 Measurement: Verified locally using Laravel feature tests to ensure the image upload limit behaves as expected.

---
*PR created automatically by Jules for task [4824421407436086712](https://jules.google.com/task/4824421407436086712) started by @Ganngann*