### PR TITLE
🎨 Palette: Enhance purchases empty state

### DIFF
--- a/pifpaf/.Jules/palette.md
+++ b/pifpaf/.Jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2026-06-13 - Empty State Improvements
+**Learning:** When adding empty states using the existing `x-ui.empty-state` component, relying on just the text without an action leaves users at a dead end.
+**Action:** Always wrap plain text empty states with `x-ui.empty-state` and include a relevant Call-To-Action (CTA) link in the `actions` slot (styled like a primary button) to guide users towards their next logical step (e.g. from an empty purchases list to the dashboard to find items).

--- a/pifpaf/resources/views/transactions/purchases.blade.php
+++ b/pifpaf/resources/views/transactions/purchases.blade.php
@@ -12,7 +12,14 @@
                     @forelse ($purchases as $transaction)
                         <x-purchase-card :transaction="$transaction" />
                     @empty
-                        <p>Vous n'avez effectué aucun achat pour le moment.</p>
+                        <x-ui.empty-state>
+                            Vous n'avez effectué aucun achat pour le moment.
+                            <x-slot name="actions">
+                                <a href="{{ route('dashboard') }}" class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 active:bg-gray-900 focus:outline-none focus:border-gray-900 focus:ring ring-gray-300 transition ease-in-out duration-150">
+                                    Découvrir les articles
+                                </a>
+                            </x-slot>
+                        </x-ui.empty-state>
                     @endforelse
 
                     @if ($purchases->hasPages())


### PR DESCRIPTION
### 💡 What:
Replaced the plain text empty state paragraph on the user's "Mes Achats" (My Purchases) page with the established `x-ui.empty-state` component. Also added a Call-to-Action (CTA) link, styled as a primary button, directing the user to the dashboard to discover items.

### 🎯 Why:
The previous empty state was a simple unstyled paragraph that left users at a dead end if they hadn't made any purchases yet. By introducing the `x-ui.empty-state` component with a CTA, we guide the user toward the core functionality of the app (browsing and buying items), which is much more intuitive and pleasant to use.

### 📸 Before/After:
**Before:** A simple left-aligned paragraph: "Vous n'avez effectué aucun achat pour le moment."
**After:** A centered dashed-border box containing the message and a dark primary action button labeled "Découvrir les articles".

### ♿ Accessibility & Standards:
- Checked that changes are kept well under 50 lines.
- Maintained keyboard accessibility: The new CTA uses a standard `<a>` tag with proper focus states (`focus:outline-none focus:border-gray-900 focus:ring ring-gray-300`) mapped directly from the existing `primary-button` component.
- Used an existing design system component (`x-ui.empty-state`).
- Did not add custom CSS.

---
*PR created automatically by Jules for task [8216919148037384650](https://jules.google.com/task/8216919148037384650) started by @Ganngann*