### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix double-crediting vulnerability in dispute resolution

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,8 @@
 **Vulnerability:** The application had a critical path traversal vulnerability in `AiRequestController.php` and `ItemController.php` where user-controlled input (`image_path`, `original_image_path`) was passed directly to `Storage::disk('public')->path()` and `Storage::disk('public')->move()` without proper sanitization. This allowed attackers to potentially read or move arbitrary files on the server using `../../` sequences.
 **Learning:** Even when using Laravel's storage facade, unsanitized user input passed to methods like `path()`, `exists()`, or `move()` is unsafe. Path parameters received from external requests must be strictly validated.
 **Prevention:** Always validate file paths from external input using strict regex constraints (e.g., `regex:/^ai_images\/[a-zA-Z0-9_\-\.]+$/`) to ensure they only point to expected directories and do not contain directory traversal sequences.
+
+## 2026-06-13 - Fix Double-Crediting in Admin Dispute Resolution
+**Vulnerability:** Dispute resolution actions (resolveForBuyer, resolveForSeller) did not verify if the dispute was still 'open', allowing admin users (or an attacker with access) to submit the action multiple times and cause double-crediting of user wallets.
+**Learning:** Replay attacks in financial transactions can lead to critical exploitation if state is not explicitly checked before processing.
+**Prevention:** Always verify entity state (e.g., check that a dispute is still 'open') before processing any financial transaction.

--- a/pifpaf/app/Http/Controllers/AdminController.php
+++ b/pifpaf/app/Http/Controllers/AdminController.php
@@ -169,6 +169,11 @@ class AdminController extends Controller
      */
     public function resolveForBuyer(Dispute $dispute)
     {
+        // Security: Prevent double-crediting and replay attacks
+        if ($dispute->status !== 'open') {
+            return redirect()->route('admin.disputes.index')->with('error', 'Ce litige a déjà été traité.');
+        }
+
         $transaction = $dispute->transaction;
         $buyer = $transaction->offer->user;
 
@@ -191,6 +196,11 @@ class AdminController extends Controller
      */
     public function resolveForSeller(Dispute $dispute)
     {
+        // Security: Prevent double-crediting and replay attacks
+        if ($dispute->status !== 'open') {
+            return redirect()->route('admin.disputes.index')->with('error', 'Ce litige a déjà été traité.');
+        }
+
         $transaction = $dispute->transaction;
         $seller = $transaction->offer->item->user;
 
@@ -213,6 +223,11 @@ class AdminController extends Controller
      */
     public function closeDispute(Dispute $dispute)
     {
+        // Security: Prevent double-crediting and replay attacks
+        if ($dispute->status !== 'open') {
+            return redirect()->route('admin.disputes.index')->with('error', 'Ce litige a déjà été traité.');
+        }
+
         $dispute->update(['status' => 'closed']);
         return redirect()->route('admin.disputes.index')->with('success', 'Le litige a été clôturé.');
     }


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Dispute resolution actions (resolveForBuyer, resolveForSeller) did not verify if the dispute was still 'open', allowing an attacker or admin to submit the action multiple times and cause double-crediting of user wallets.
🎯 Impact: Exploitation of this business logic flaw could lead to unauthorized financial gains and severe manipulation of user wallets.
🔧 Fix: Added explicit state verification (`if ($dispute->status !== 'open')`) with early returns in `resolveForBuyer`, `resolveForSeller`, and `closeDispute` methods within `AdminController`.
✅ Verification: Tested via the automated test suite, specifically `php artisan test --filter AdminDisputesTest`, which passes. Code has been manually verified to prevent state manipulation.

---
*PR created automatically by Jules for task [2562884112524911679](https://jules.google.com/task/2562884112524911679) started by @Ganngann*