### PR TITLE
⚡ Bolt: Fix N+1 query bottleneck during multi-image uploads

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -2,3 +2,6 @@
 **Learning:** Checking `Auth::user()->unreadNotifications->count()` inside the navigation layout triggers an N+1 query issue since notifications might not be loaded, and `count()` triggers a separate count query on the relation each time it's called (or loads all notifications). Actually, it loads the relation because it uses the property `unreadNotifications` and then calls `count()` on the collection. In this case, `unreadNotifications()->count()` is much more efficient as it performs an aggregate query, but even better is doing it right in a View Composer if needed, or just `unreadNotifications()->count()`. Wait, since it's `Auth::user()->unreadNotifications->count()`, it loads ALL unread notifications into memory just to count them!
 
 **Action:** Replace `$user->unreadNotifications->count()` with `$user->unreadNotifications()->count()`. This executes a simple `COUNT(*)` query without fetching the actual model records.
+## 2024-05-16 - [N+1 query in file upload loop]
+**Learning:** Calling `$item->images()->count()` inside a `foreach` loop executing for each uploaded file triggers a new COUNT(*) database query on every iteration.
+**Action:** Calculate the count once before the loop and manually increment the cached value inside the loop to avoid N+1 queries.

--- a/pifpaf/app/Http/Controllers/ItemController.php
+++ b/pifpaf/app/Http/Controllers/ItemController.php
@@ -406,9 +406,12 @@ class ItemController extends Controller
             // On récupère le dernier ordre pour continuer la séquence
             $order = $item->images()->max('order') + 1;
 
+            // Cache image count to avoid N+1 query in loop
+            $currentImageCount = $item->images()->count();
+
             foreach ($request->file('images') as $imageFile) {
                 // On vérifie qu'on ne dépasse pas la limite totale de 10 images
-                if ($item->images()->count() >= 10) {
+                if ($currentImageCount >= 10) {
                     break;
                 }
 
@@ -417,6 +420,7 @@ class ItemController extends Controller
                     'path' => $path,
                     'order' => $order++,
                 ]);
+                $currentImageCount++;
             }
         }
 


### PR DESCRIPTION
💡 **What:** Extract `$item->images()->count()` outside the `foreach` loop when uploading multiple images in `ItemController@update`.
🎯 **Why:** To eliminate an N+1 performance bottleneck. Previously, the system executed a new database `COUNT(*)` query on the `item_images` table for *every single uploaded image* just to enforce the 10-image maximum limit.
📊 **Impact:** Reduces database queries linearly based on the number of uploaded files. For example, uploading 5 files previously triggered 5 `COUNT(*)` queries; now it triggers only 1.
🔬 **Measurement:** Verify by uploading multiple images while observing the database query logs (e.g., via Laravel Telescope or raw query logging). The `COUNT(*)` query should only fire once.

---
*PR created automatically by Jules for task [2783462121457209478](https://jules.google.com/task/2783462121457209478) started by @Ganngann*