### PR TITLE
⚡ Bolt: [performance] Fix N+1 database query inside ItemController upload loop

### DIFF
--- a/pifpaf/.jules/bolt.md
+++ b/pifpaf/.jules/bolt.md
@@ -1,0 +1,4 @@
+
+## 2024-06-15 - Cached Relationship Count in Loop
+**Learning:** Checking a relationship count (like `$item->images()->count()`) inside a loop causes a new database query on each iteration. This is a common N+1 performance issue when dealing with arrays of inputs (like image uploads).
+**Action:** Always cache aggregate functions like `count()` outside the loop and increment/decrement the cached variable internally if needed.

--- a/pifpaf/app/Http/Controllers/ItemController.php
+++ b/pifpaf/app/Http/Controllers/ItemController.php
@@ -406,9 +406,12 @@ class ItemController extends Controller
             // On récupère le dernier ordre pour continuer la séquence
             $order = $item->images()->max('order') + 1;
 
+            // ⚡ Bolt: Cache image count before loop to prevent N+1 query performance issues
+            $currentImageCount = $item->images()->count();
+
             foreach ($request->file('images') as $imageFile) {
                 // On vérifie qu'on ne dépasse pas la limite totale de 10 images
-                if ($item->images()->count() >= 10) {
+                if ($currentImageCount >= 10) {
                     break;
                 }
 
@@ -417,6 +420,8 @@ class ItemController extends Controller
                     'path' => $path,
                     'order' => $order++,
                 ]);
+
+                $currentImageCount++;
             }
         }
 


### PR DESCRIPTION
💡 What: Cached the `$item->images()->count()` value outside the `foreach` loop when handling multiple image uploads in `ItemController@update`, incrementing a local variable instead of querying the database on each iteration.
🎯 Why: Calling a relationship method with `->count()` inside a loop executes a new aggregate query on every iteration, leading to an N+1 performance issue.
📊 Impact: Reduces database queries during image uploads from O(N) to O(1), saving up to 10 queries per request when uploading maximum allowed images.
🔬 Measurement: Covered by the existing test suite, verified by `php artisan test --filter ItemController`. Also recorded a new learning in `.jules/bolt.md`.

---
*PR created automatically by Jules for task [3269280076498145543](https://jules.google.com/task/3269280076498145543) started by @Ganngann*