### PR TITLE
🎨 Palette: Replace unstyled empty states with consistent x-ui.empty-state components

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2026-05-16 - Add ARIA Labels to Navigation Elements
 **Learning:** Icon-only links and toggle buttons (like the notifications bell and hamburger menu) are common in Laravel Breeze/Alpine navigation components but often lack accessible labels by default.
 **Action:** When adding or reviewing icon-only interactive elements, ensure `aria-label` is present. For elements that toggle state (like dropdowns or mobile menus), bind `aria-expanded` to the state variable (e.g., `:aria-expanded="open.toString()"` in Alpine.js) to communicate state to screen readers.
+## 2026-05-16 - Replace unstyled empty states with components
+**Learning:** Using unstyled paragraphs (`<p>`) for empty states in lists (like addresses or bank accounts) creates a poor, inconsistent user experience without clear next steps.
+**Action:** Always replace unstyled empty states with the `x-ui.empty-state` component and include a primary call-to-action (CTA) inside its `<x-slot name="actions">`. When doing so, ensure top-level CTAs are conditionally hidden to prevent duplicate buttons.

--- a/pifpaf/resources/views/profile/addresses/index.blade.php
+++ b/pifpaf/resources/views/profile/addresses/index.blade.php
@@ -9,14 +9,23 @@
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
             <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
                 <div class="p-6 bg-white border-b border-gray-200">
-                    <div class="flex justify-between items-center mb-4">
-                        <h3 class="text-lg font-semibold">Toutes mes adresses</h3>
-                        <a href="{{ route('profile.addresses.create') }}" class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 active:bg-gray-900 focus:outline-none focus:border-gray-900 focus:ring ring-gray-300 disabled:opacity-25 transition ease-in-out duration-150">
-                            Ajouter une adresse
-                        </a>
-                    </div>
+                    @if($addresses->isNotEmpty())
+                        <div class="flex justify-between items-center mb-4">
+                            <h3 class="text-lg font-semibold">Toutes mes adresses</h3>
+                            <a href="{{ route('profile.addresses.create') }}" class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 active:bg-gray-900 focus:outline-none focus:border-gray-900 focus:ring ring-gray-300 disabled:opacity-25 transition ease-in-out duration-150">
+                                Ajouter une adresse
+                            </a>
+                        </div>
+                    @endif
                     @if($addresses->isEmpty())
-                        <p>Vous n'avez pas encore d'adresse enregistrée.</p>
+                        <x-ui.empty-state>
+                            Vous n'avez pas encore d'adresse enregistrée.
+                            <x-slot name="actions">
+                                <a href="{{ route('profile.addresses.create') }}" class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 active:bg-gray-900 focus:outline-none focus:border-gray-900 focus:ring ring-gray-300 disabled:opacity-25 transition ease-in-out duration-150">
+                                    Ajouter une adresse
+                                </a>
+                            </x-slot>
+                        </x-ui.empty-state>
                     @else
                         <div class="space-y-4">
                             @foreach($addresses as $address)

--- a/pifpaf/resources/views/profile/bank-accounts/index.blade.php
+++ b/pifpaf/resources/views/profile/bank-accounts/index.blade.php
@@ -9,12 +9,14 @@
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
             <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
                 <div class="p-6 bg-white border-b border-gray-200">
-                    <div class="flex justify-between items-center mb-4">
-                        <h3 class="text-lg font-medium text-gray-900">Vos comptes bancaires</h3>
-                        <a href="{{ route('profile.bank-accounts.create') }}" class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 active:bg-gray-900 focus:outline-none focus:border-gray-900 focus:ring ring-gray-300 disabled:opacity-25 transition ease-in-out duration-150">
-                            {{ __('Ajouter un compte') }}
-                        </a>
-                    </div>
+                    @if ($bankAccounts->isNotEmpty())
+                        <div class="flex justify-between items-center mb-4">
+                            <h3 class="text-lg font-medium text-gray-900">Vos comptes bancaires</h3>
+                            <a href="{{ route('profile.bank-accounts.create') }}" class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 active:bg-gray-900 focus:outline-none focus:border-gray-900 focus:ring ring-gray-300 disabled:opacity-25 transition ease-in-out duration-150">
+                                {{ __('Ajouter un compte') }}
+                            </a>
+                        </div>
+                    @endif
 
                     @if (session('success'))
                         <div class="mb-4 font-medium text-sm text-green-600">
@@ -24,7 +26,14 @@
 
                     <div class="mt-6">
                         @if ($bankAccounts->isEmpty())
-                            <p>Vous n'avez pas encore de compte bancaire enregistré.</p>
+                            <x-ui.empty-state>
+                                Vous n'avez pas encore de compte bancaire enregistré.
+                                <x-slot name="actions">
+                                    <a href="{{ route('profile.bank-accounts.create') }}" class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 active:bg-gray-900 focus:outline-none focus:border-gray-900 focus:ring ring-gray-300 disabled:opacity-25 transition ease-in-out duration-150">
+                                        {{ __('Ajouter un compte') }}
+                                    </a>
+                                </x-slot>
+                            </x-ui.empty-state>
                         @else
                             <ul>
                                 @foreach ($bankAccounts as $account)

--- a/pifpaf/resources/views/transactions/purchases.blade.php
+++ b/pifpaf/resources/views/transactions/purchases.blade.php
@@ -12,7 +12,9 @@
                     @forelse ($purchases as $transaction)
                         <x-purchase-card :transaction="$transaction" />
                     @empty
-                        <p>Vous n'avez effectué aucun achat pour le moment.</p>
+                        <x-ui.empty-state>
+                            Vous n'avez effectué aucun achat pour le moment.
+                        </x-ui.empty-state>
                     @endforelse
 
                     @if ($purchases->hasPages())


### PR DESCRIPTION
💡 **What**: Replaced raw, unstyled `<p>` empty state tags with the centralized `x-ui.empty-state` Blade component across Profile Addresses, Profile Bank Accounts, and Transactions Purchases views. Moved the "Add" CTAs directly into the empty state component's `<x-slot name="actions">`. Conditionally hid top-level CTAs when lists are empty to avoid duplication.
🎯 **Why**: Using standardized UI components ensures visual consistency across the app, while putting primary CTAs directly into the empty state provides a clearer, more immediate next step for the user.
📸 **Before/After**: Empty states are now neatly bounded by a dashed container with centered text, rather than a raw left-aligned paragraph. 
♿ **Accessibility**: N/A - primarily visual and interaction improvements.

---
*PR created automatically by Jules for task [16762978011529741989](https://jules.google.com/task/16762978011529741989) started by @Ganngann*