### PR TITLE
⚡ Bolt: Fix N+1 query in ItemController update method

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -2,3 +2,7 @@
 **Learning:** Checking `Auth::user()->unreadNotifications->count()` inside the navigation layout triggers an N+1 query issue since notifications might not be loaded, and `count()` triggers a separate count query on the relation each time it's called (or loads all notifications). Actually, it loads the relation because it uses the property `unreadNotifications` and then calls `count()` on the collection. In this case, `unreadNotifications()->count()` is much more efficient as it performs an aggregate query, but even better is doing it right in a View Composer if needed, or just `unreadNotifications()->count()`. Wait, since it's `Auth::user()->unreadNotifications->count()`, it loads ALL unread notifications into memory just to count them!
 
 **Action:** Replace `$user->unreadNotifications->count()` with `$user->unreadNotifications()->count()`. This executes a simple `COUNT(*)` query without fetching the actual model records.
+
+## 2024-06-16 - [Fix N+1 query in images count loop]
+**Learning:** Calling $item->images()->count() inside a foreach loop executes a separate SELECT COUNT(*) query for every iteration. This causes a massive N+1 query problem proportional to the number of elements being processed.
+**Action:** Always cache the results of relationship aggregate queries like ->count() before the loop to execute only a single query and increment the cached variable inside the loop if necessary.

--- a/pifpaf/app/Http/Controllers/ItemController.php
+++ b/pifpaf/app/Http/Controllers/ItemController.php
@@ -406,9 +406,13 @@ class ItemController extends Controller
             // On récupère le dernier ordre pour continuer la séquence
             $order = $item->images()->max('order') + 1;
 
+            // ⚡ BOLT OPTIMIZATION: Cache image count to prevent N+1 query problem inside the loop
+            // Expected impact: Eliminates X database queries where X is the number of uploaded images
+            $currentImagesCount = $item->images()->count();
+
             foreach ($request->file('images') as $imageFile) {
                 // On vérifie qu'on ne dépasse pas la limite totale de 10 images
-                if ($item->images()->count() >= 10) {
+                if ($currentImagesCount >= 10) {
                     break;
                 }
 
@@ -417,6 +421,7 @@ class ItemController extends Controller
                     'path' => $path,
                     'order' => $order++,
                 ]);
+                $currentImagesCount++;
             }
         }
 


### PR DESCRIPTION
💡 **What:** Caches the `$item->images()->count()` result before iterating over uploaded images in the `ItemController@update` method, and increments it inside the loop.
🎯 **Why:** To eliminate an N+1 query problem. Previously, `$item->images()->count()` executed a database query on every iteration, leading to multiple redundant `SELECT COUNT(*)` queries proportional to the number of uploaded images.
📊 **Impact:** Eliminates X-1 redundant database queries where X is the number of uploaded images, speeding up the item update request.
🔬 **Measurement:** Can be verified using Laravel Telescope or Debugbar by inspecting the executed queries when updating an item with multiple images.

---
*PR created automatically by Jules for task [3066464714939907664](https://jules.google.com/task/3066464714939907664) started by @Ganngann*