### PR TITLE
🛡️ Sentinel: [HIGH] Fix Insecure Direct Object Reference (IDOR) in image reordering

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,8 @@
 **Vulnerability:** The application had a critical path traversal vulnerability in `AiRequestController.php` and `ItemController.php` where user-controlled input (`image_path`, `original_image_path`) was passed directly to `Storage::disk('public')->path()` and `Storage::disk('public')->move()` without proper sanitization. This allowed attackers to potentially read or move arbitrary files on the server using `../../` sequences.
 **Learning:** Even when using Laravel's storage facade, unsanitized user input passed to methods like `path()`, `exists()`, or `move()` is unsafe. Path parameters received from external requests must be strictly validated.
 **Prevention:** Always validate file paths from external input using strict regex constraints (e.g., `regex:/^ai_images\/[a-zA-Z0-9_\-\.]+$/`) to ensure they only point to expected directories and do not contain directory traversal sequences.
+
+## 2024-05-24 - Fix IDOR in bulk image reordering
+**Vulnerability:** IDOR in `ItemImageController@reorder` because authorization was only checked for the first element in the array of IDs.
+**Learning:** When authorizing bulk operations that iterate over an array of IDs, ensure authorization is explicitly verified for every item in the array, not just the first one, to prevent IDOR (Insecure Direct Object Reference) vulnerabilities. Use `with('item')` to avoid N+1 queries.
+**Prevention:** Always validate ownership/authorization for all entities involved in a bulk update or delete operation.

--- a/pifpaf/app/Http/Controllers/ItemImageController.php
+++ b/pifpaf/app/Http/Controllers/ItemImageController.php
@@ -69,8 +69,11 @@ class ItemImageController extends Controller
             'ids.*' => 'exists:item_images,id',
         ]);
 
-        $itemImage = ItemImage::find($request->ids[0]);
-        $this->authorize('update', $itemImage->item);
+        // Security fix: Authorize ALL images being reordered, not just the first one
+        $images = ItemImage::with('item')->whereIn('id', $request->ids)->get();
+        foreach ($images as $image) {
+            $this->authorize('update', $image->item);
+        }
 
         foreach ($request->ids as $index => $id) {
             ItemImage::where('id', $id)->update(['order' => $index]);

--- a/pifpaf/tests/Feature/ItemImageIdorTest.php
+++ b/pifpaf/tests/Feature/ItemImageIdorTest.php
@@ -1,0 +1,39 @@
+<?php
+namespace Tests\Feature;
+use App\Models\Item;
+use App\Models\ItemImage;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ItemImageIdorTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_cannot_reorder_other_users_images_with_mixed_ids(): void
+    {
+        $attacker = User::factory()->create();
+        $attackerItem = Item::factory()->create(['user_id' => $attacker->id]);
+        $attackerImage = ItemImage::create([
+            'item_id' => $attackerItem->id,
+            'path' => 'attacker.jpg',
+            'is_primary' => false,
+            'order' => 0,
+        ]);
+
+        $victim = User::factory()->create();
+        $victimItem = Item::factory()->create(['user_id' => $victim->id]);
+        $victimImage = ItemImage::create([
+            'item_id' => $victimItem->id,
+            'path' => 'victim.jpg',
+            'is_primary' => false,
+            'order' => 0,
+        ]);
+
+        $response = $this->actingAs($attacker)->postJson(route('item-images.reorder'), [
+            'ids' => [$attackerImage->id, $victimImage->id],
+        ]);
+
+        $response->assertForbidden();
+    }
+}


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** An Insecure Direct Object Reference (IDOR) vulnerability was identified in `ItemImageController@reorder`. The authorization logic only checked if the user owned the *first* item image in the `ids` array provided in the request. By passing an owned image ID as the first element and appending other users' image IDs, an attacker could unauthorizedly reorder images belonging to other users.
🎯 **Impact:** An attacker could tamper with the presentation of other users' items by reordering their images, leading to unauthorized modification of item listings.
🔧 **Fix:** Modified `ItemImageController@reorder` to fetch all images provided in the `$request->ids` array and perform an authorization check on every single image before processing the updates.
✅ **Verification:** Verified by checking the updated test `ItemImageIdorTest`, testing `tests/Feature/ItemImageControllerTest.php`, and running the entire `php artisan test` suite successfully.

---
*PR created automatically by Jules for task [12336222196230056928](https://jules.google.com/task/12336222196230056928) started by @Ganngann*