### PR TITLE
🛡️ Sentinel: [HIGH] Fix IDOR in bulk image reordering

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,7 @@
 **Vulnerability:** The application had a critical path traversal vulnerability in `AiRequestController.php` and `ItemController.php` where user-controlled input (`image_path`, `original_image_path`) was passed directly to `Storage::disk('public')->path()` and `Storage::disk('public')->move()` without proper sanitization. This allowed attackers to potentially read or move arbitrary files on the server using `../../` sequences.
 **Learning:** Even when using Laravel's storage facade, unsanitized user input passed to methods like `path()`, `exists()`, or `move()` is unsafe. Path parameters received from external requests must be strictly validated.
 **Prevention:** Always validate file paths from external input using strict regex constraints (e.g., `regex:/^ai_images\/[a-zA-Z0-9_\-\.]+$/`) to ensure they only point to expected directories and do not contain directory traversal sequences.
+## 2025-03-01 - IDOR in Bulk Operations
+**Vulnerability:** Bulk operations (like image reordering) iterating over an array of IDs failed to authorize every item, leading to an Insecure Direct Object Reference (IDOR) risk if a user maliciously provided IDs belonging to other users.
+**Learning:** When looping over IDs in a request, authorization must be verified explicitly for *every* individual item retrieved, not just the first one or the request generally.
+**Prevention:** Eager load the required relationship with `with()` before iterating, and use `$this->authorize()` on each instance within the loop to ensure strict ownership verification across all processed items.

--- a/pifpaf/app/Http/Controllers/ItemImageController.php
+++ b/pifpaf/app/Http/Controllers/ItemImageController.php
@@ -69,8 +69,11 @@ class ItemImageController extends Controller
             'ids.*' => 'exists:item_images,id',
         ]);
 
-        $itemImage = ItemImage::find($request->ids[0]);
-        $this->authorize('update', $itemImage->item);
+        // SECURITY: Verify authorization for all requested images to prevent IDOR
+        $images = ItemImage::with('item')->whereIn('id', $request->ids)->get();
+        foreach ($images as $image) {
+            $this->authorize('update', $image->item);
+        }
 
         foreach ($request->ids as $index => $id) {
             ItemImage::where('id', $id)->update(['order' => $index]);


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: An Insecure Direct Object Reference (IDOR) vulnerability existed in `ItemImageController::reorder()`. The method iterated over an array of image IDs to update their display order but only verified authorization (`$this->authorize('update', $image->item)`) for the very first image ID in the array. This allowed a malicious user to craft a payload where the first ID belonged to them, but subsequent IDs belonged to other users, successfully bypassing authorization and modifying other users' image orderings.
🎯 **Impact**: Attackers could arbitrarily reorder images belonging to other users' items.
🔧 **Fix**: Updated the `reorder` method to retrieve all requested images eagerly with their parent `item` relationship to avoid N+1 queries. It then iterates through all retrieved images and explicitly calls `$this->authorize('update', $image->item)` on each one before executing the bulk update.
✅ **Verification**: Run `php artisan test --filter ItemImageControllerTest` to ensure that standard authorization checks (and tests like `user cannot modify other users images`) continue to pass and are applied comprehensively.

---
*PR created automatically by Jules for task [7373725913057824775](https://jules.google.com/task/7373725913057824775) started by @Ganngann*