### PR TITLE
🎨 Palette: Replace unstyled empty state in purchases with x-ui.empty-state and CTA

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-05-16 - Add ARIA Labels to Navigation Elements
 **Learning:** Icon-only links and toggle buttons (like the notifications bell and hamburger menu) are common in Laravel Breeze/Alpine navigation components but often lack accessible labels by default.
 **Action:** When adding or reviewing icon-only interactive elements, ensure `aria-label` is present. For elements that toggle state (like dropdowns or mobile menus), bind `aria-expanded` to the state variable (e.g., `:aria-expanded="open.toString()"` in Alpine.js) to communicate state to screen readers.
+
+## 2025-06-17 - Replace unstyled empty states with x-ui.empty-state and CTA
+**Learning:** Unstyled `<p>` tags for empty states (like on the purchases page) provide poor UX. The project has a dedicated `x-ui.empty-state` component that should be used for visual consistency. Furthermore, empty states should always include a helpful Call-To-Action (CTA) to guide the user.
+**Action:** Always use `<x-ui.empty-state>` for empty lists, and include a CTA button (using the `<x-slot name="actions">` slot and applying primary button classes to an `<a>` tag) to help users take the next logical step.

--- a/pifpaf/resources/views/transactions/purchases.blade.php
+++ b/pifpaf/resources/views/transactions/purchases.blade.php
@@ -12,7 +12,14 @@
                     @forelse ($purchases as $transaction)
                         <x-purchase-card :transaction="$transaction" />
                     @empty
-                        <p>Vous n'avez effectué aucun achat pour le moment.</p>
+                        <x-ui.empty-state>
+                            Vous n'avez effectué aucun achat pour le moment.
+                            <x-slot name="actions">
+                                <a href="{{ route('welcome') }}" class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 active:bg-gray-900 focus:outline-none focus:border-gray-900 focus:ring ring-gray-300 disabled:opacity-25 transition ease-in-out duration-150">
+                                    Explorer les annonces
+                                </a>
+                            </x-slot>
+                        </x-ui.empty-state>
                     @endforelse
 
                     @if ($purchases->hasPages())


### PR DESCRIPTION
Replaced the plain text empty state paragraph in transactions/purchases.blade.php with the x-ui.empty-state Blade component. Added a styled "Explorer les annonces" Call-to-Action button linking to the welcome route, improving UX and ensuring consistency with the project's design system. Also recorded learning in .Jules/palette.md.

---
*PR created automatically by Jules for task [3476412132608333630](https://jules.google.com/task/3476412132608333630) started by @Ganngann*