### PR TITLE
⚡ Bolt: Fix N+1 query bottleneck during file uploads

### DIFF
--- a/pifpaf/.jules/bolt.md
+++ b/pifpaf/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-06-17 - [N+1 Query in File Upload Loops]
+**Learning:** Checking `$item->images()->count()` repeatedly inside a loop (like a `foreach` loop processing multiple file uploads) will execute a new database query on each iteration. This N+1 query issue occurs because the query builder method `count()` runs every time it is invoked, which is especially problematic and unnecessary during file processing loops.
+**Action:** Always evaluate relational counts (e.g., `$count = $item->images()->count()`) outside the loop into a local variable and increment it manually inside the loop if the state changes.

--- a/pifpaf/app/Http/Controllers/ItemController.php
+++ b/pifpaf/app/Http/Controllers/ItemController.php
@@ -406,9 +406,13 @@ class ItemController extends Controller
             // On récupère le dernier ordre pour continuer la séquence
             $order = $item->images()->max('order') + 1;
 
+            // ⚡ Bolt Optimization: Pré-calculer le nombre d'images pour éviter le N+1
+            // lors de la validation de la limite des 10 images.
+            $currentImagesCount = $item->images()->count();
+
             foreach ($request->file('images') as $imageFile) {
                 // On vérifie qu'on ne dépasse pas la limite totale de 10 images
-                if ($item->images()->count() >= 10) {
+                if ($currentImagesCount >= 10) {
                     break;
                 }
 
@@ -417,6 +421,8 @@ class ItemController extends Controller
                     'path' => $path,
                     'order' => $order++,
                 ]);
+
+                $currentImagesCount++;
             }
         }
 


### PR DESCRIPTION
💡 What: Pre-calculate the total image count of an item before entering the `foreach` loop for file uploads. The `count()` is then manually incremented during each iteration instead of querying the database repeatedly.

🎯 Why: In `ItemController::update`, `$item->images()->count()` was being called within the `foreach` loop that processes newly uploaded images. This resulted in an N+1 query problem, as `count()` triggers a `SELECT COUNT(*)` database query on each iteration. By storing the initial count in a local variable, we transform O(N) database queries into a single O(1) query.

📊 Impact: Reduces database load during file uploads by eliminating unnecessary sequential `COUNT(*)` queries on the `item_images` table.

🔬 Measurement: The expected behavior is identical to before, but it executes faster. The improvement can be verified by uploading multiple images at once (e.g., 5 images) and checking database query logs. The tests `php artisan test` have passed.

---
*PR created automatically by Jules for task [15763370292294511181](https://jules.google.com/task/15763370292294511181) started by @Ganngann*