### PR TITLE
⚡ Bolt: Fix N+1 query issue in item image upload loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -2,3 +2,7 @@
 **Learning:** Checking `Auth::user()->unreadNotifications->count()` inside the navigation layout triggers an N+1 query issue since notifications might not be loaded, and `count()` triggers a separate count query on the relation each time it's called (or loads all notifications). Actually, it loads the relation because it uses the property `unreadNotifications` and then calls `count()` on the collection. In this case, `unreadNotifications()->count()` is much more efficient as it performs an aggregate query, but even better is doing it right in a View Composer if needed, or just `unreadNotifications()->count()`. Wait, since it's `Auth::user()->unreadNotifications->count()`, it loads ALL unread notifications into memory just to count them!
 
 **Action:** Replace `$user->unreadNotifications->count()` with `$user->unreadNotifications()->count()`. This executes a simple `COUNT(*)` query without fetching the actual model records.
+
+## 2026-06-19 - [N+1 query in file upload loop]
+**Learning:** Calling aggregate relation methods like `$item->images()->count()` inside a loop executes a new database query on every iteration, leading to an N+1 query performance bottleneck.
+**Action:** Pre-calculate the relationship count outside the loop and manually increment the local variable inside the loop to avoid redundant database queries.

--- a/pifpaf/app/Http/Controllers/ItemController.php
+++ b/pifpaf/app/Http/Controllers/ItemController.php
@@ -406,9 +406,12 @@ class ItemController extends Controller
             // On récupère le dernier ordre pour continuer la séquence
             $order = $item->images()->max('order') + 1;
 
+            // ⚡ Bolt: Pre-calculate the relationship count to avoid N+1 query performance bottleneck in the loop
+            $currentImageCount = $item->images()->count();
+
             foreach ($request->file('images') as $imageFile) {
                 // On vérifie qu'on ne dépasse pas la limite totale de 10 images
-                if ($item->images()->count() >= 10) {
+                if ($currentImageCount >= 10) {
                     break;
                 }
 
@@ -417,6 +420,7 @@ class ItemController extends Controller
                     'path' => $path,
                     'order' => $order++,
                 ]);
+                $currentImageCount++;
             }
         }
 


### PR DESCRIPTION
💡 What: Replaced `$item->images()->count()` inside the `foreach` file upload loop with a pre-calculated local variable (`$currentImageCount`) that is manually incremented on each iteration.
🎯 Why: Calling `$item->images()->count()` inside a loop executes a new database query on every iteration, leading to an N+1 query performance bottleneck, especially given the allowed upload of multiple images.
📊 Impact: Eliminates up to 10 redundant database count queries during the image upload process, improving the performance of the item update endpoint.
🔬 Measurement: Verified the code uses a pre-calculated `$currentImageCount` local variable and successfully ran all tests to ensure correct behavior.

---
*PR created automatically by Jules for task [14489398629304873318](https://jules.google.com/task/14489398629304873318) started by @Ganngann*