### PR TITLE
⚡ Bolt: Prevent N+1 query when checking image limit in ItemController

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -2,3 +2,7 @@
 **Learning:** Checking `Auth::user()->unreadNotifications->count()` inside the navigation layout triggers an N+1 query issue since notifications might not be loaded, and `count()` triggers a separate count query on the relation each time it's called (or loads all notifications). Actually, it loads the relation because it uses the property `unreadNotifications` and then calls `count()` on the collection. In this case, `unreadNotifications()->count()` is much more efficient as it performs an aggregate query, but even better is doing it right in a View Composer if needed, or just `unreadNotifications()->count()`. Wait, since it's `Auth::user()->unreadNotifications->count()`, it loads ALL unread notifications into memory just to count them!
 
 **Action:** Replace `$user->unreadNotifications->count()` with `$user->unreadNotifications()->count()`. This executes a simple `COUNT(*)` query without fetching the actual model records.
+
+## 2024-06-20 - [N+1 query during iterative upload limit check]
+**Learning:** Calling `$item->images()->count()` repeatedly inside a `foreach` loop that processes file uploads triggers a separate `COUNT` query on every iteration, leading to an N+1 query issue.
+**Action:** Pre-calculate the relationship count outside of loops and manually increment the local variable inside the loop to avoid redundant database queries.

--- a/pifpaf/app/Http/Controllers/ItemController.php
+++ b/pifpaf/app/Http/Controllers/ItemController.php
@@ -406,9 +406,13 @@ class ItemController extends Controller
             // On récupère le dernier ordre pour continuer la séquence
             $order = $item->images()->max('order') + 1;
 
+            // ⚡ Bolt Optimization: Pre-calculate image count outside the loop
+            // to avoid N+1 count() queries for each uploaded file.
+            $currentImageCount = $item->images()->count();
+
             foreach ($request->file('images') as $imageFile) {
                 // On vérifie qu'on ne dépasse pas la limite totale de 10 images
-                if ($item->images()->count() >= 10) {
+                if ($currentImageCount >= 10) {
                     break;
                 }
 
@@ -417,6 +421,8 @@ class ItemController extends Controller
                     'path' => $path,
                     'order' => $order++,
                 ]);
+
+                $currentImageCount++;
             }
         }
 


### PR DESCRIPTION
**💡 What:** 
Pre-calculated the image count (`$item->images()->count()`) outside the `foreach` file upload loop in `ItemController@update` and manually incremented it.

**🎯 Why:** 
The original implementation ran `$item->images()->count()` during every iteration of the `foreach` loop. If a user uploads 10 images, this executes a separate `SELECT COUNT(*)` database query 10 times, causing an N+1 query performance bottleneck.

**📊 Impact:** 
Reduces database calls during image uploads from N+1 (where N is the number of uploaded images) to a single `count()` query, accelerating the file upload transaction and lowering database load.

**🔬 Measurement:** 
Run `php artisan test` locally to ensure the image upload logic (including the hard limit of 10) functions properly. Inspect database logs during file uploads to verify `COUNT` is only executed once.

---
*PR created automatically by Jules for task [15229699204897471117](https://jules.google.com/task/15229699204897471117) started by @Ganngann*