### PR TITLE
🛡️ Sentinel: [HIGH] Fix Insecure Direct Object Reference in ItemImage reordering

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,7 @@
 **Vulnerability:** The application had a critical path traversal vulnerability in `AiRequestController.php` and `ItemController.php` where user-controlled input (`image_path`, `original_image_path`) was passed directly to `Storage::disk('public')->path()` and `Storage::disk('public')->move()` without proper sanitization. This allowed attackers to potentially read or move arbitrary files on the server using `../../` sequences.
 **Learning:** Even when using Laravel's storage facade, unsanitized user input passed to methods like `path()`, `exists()`, or `move()` is unsafe. Path parameters received from external requests must be strictly validated.
 **Prevention:** Always validate file paths from external input using strict regex constraints (e.g., `regex:/^ai_images\/[a-zA-Z0-9_\-\.]+$/`) to ensure they only point to expected directories and do not contain directory traversal sequences.
+## 2025-05-20 - [Fix Insecure Direct Object Reference in ItemImage reordering]
+**Vulnerability:** The reorder method only authorized the user against the first ItemImage in the provided ids array, allowing an attacker to change the order column of ItemImage records belonging to other users by appending their IDs to the array.
+**Learning:** When performing bulk operations involving multiple model IDs, each model must be individually authorized to prevent IDOR vulnerabilities.
+**Prevention:** Always iterate through the array of IDs and authorize each corresponding model instance or use a query that implicitly scopes updates to the authenticated user's records.

--- a/pifpaf/app/Http/Controllers/ItemImageController.php
+++ b/pifpaf/app/Http/Controllers/ItemImageController.php
@@ -69,8 +69,13 @@ class ItemImageController extends Controller
             'ids.*' => 'exists:item_images,id',
         ]);
 
-        $itemImage = ItemImage::find($request->ids[0]);
-        $this->authorize('update', $itemImage->item);
+        // Security Fix: Prevent IDOR by authorizing each individual item.
+        // Previously, only the first image was checked, allowing attackers to reorder other users' images.
+        $itemImages = ItemImage::with('item')->whereIn('id', $request->ids)->get();
+
+        foreach ($itemImages as $itemImage) {
+            $this->authorize('update', $itemImage->item);
+        }
 
         foreach ($request->ids as $index => $id) {
             ItemImage::where('id', $id)->update(['order' => $index]);


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Insecure Direct Object Reference (IDOR) in `ItemImageController@reorder`. The method only authorized the user against the *first* `ItemImage` ID provided in the `ids` array. By placing their own ID first, an attacker could append IDs of `ItemImage` records belonging to other users and illegally update their `order` column.
🎯 **Impact:** An attacker could reorder images on any user's item, leading to a defaced appearance or misrepresentation of listings.
🔧 **Fix:** Refactored the `reorder` method to query all requested `ItemImage` models at once (eager loading the `item` relationship) and explicitly call `$this->authorize('update', $itemImage->item);` for every single image before processing the order updates.
✅ **Verification:** A test script verified that appending an unowned ID to the payload now strictly throws an `AuthorizationException`. The PHPUnit test suite was executed locally and confirmed no regressions (226 tests passed).

---
*PR created automatically by Jules for task [9720319638765382091](https://jules.google.com/task/9720319638765382091) started by @Ganngann*