### PR TITLE
🎨 Palette: Add CTA to empty purchases state

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-05-16 - Add ARIA Labels to Navigation Elements
 **Learning:** Icon-only links and toggle buttons (like the notifications bell and hamburger menu) are common in Laravel Breeze/Alpine navigation components but often lack accessible labels by default.
 **Action:** When adding or reviewing icon-only interactive elements, ensure `aria-label` is present. For elements that toggle state (like dropdowns or mobile menus), bind `aria-expanded` to the state variable (e.g., `:aria-expanded="open.toString()"` in Alpine.js) to communicate state to screen readers.
+
+## 2026-06-20 - Consistent Empty States with CTA
+**Learning:** Raw text empty states without clear next steps create dead-ends in user journeys. Wrapping them in a consistent component and adding a Call-To-Action (CTA) significantly improves UX by guiding users to the next valuable action.
+**Action:** When implementing or updating empty states, always use the `x-ui.empty-state` component and include an actionable `<x-slot name="actions">` CTA using existing button styles.

--- a/pifpaf/resources/views/transactions/purchases.blade.php
+++ b/pifpaf/resources/views/transactions/purchases.blade.php
@@ -12,7 +12,14 @@
                     @forelse ($purchases as $transaction)
                         <x-purchase-card :transaction="$transaction" />
                     @empty
-                        <p>Vous n'avez effectué aucun achat pour le moment.</p>
+                        <x-ui.empty-state>
+                            Vous n'avez effectué aucun achat pour le moment.
+                            <x-slot name="actions">
+                                <a href="{{ route('dashboard') }}" class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 active:bg-gray-900 focus:outline-none focus:border-gray-900 focus:ring ring-gray-300 disabled:opacity-25 transition ease-in-out duration-150">
+                                    Trouver des articles
+                                </a>
+                            </x-slot>
+                        </x-ui.empty-state>
                     @endforelse
 
                     @if ($purchases->hasPages())


### PR DESCRIPTION
### 💡 What
Updated the "Mes Achats" (My Purchases) page to use the standardized `x-ui.empty-state` component and added a "Trouver des articles" (Find items) Call-to-Action button.

### 🎯 Why
Raw text empty states without clear next steps create dead-ends in user journeys. Wrapping them in a consistent component and adding a Call-To-Action (CTA) significantly improves UX by guiding users to the next valuable action (in this case, back to the dashboard to find items).

### 📸 Before/After
**Before:** Just plain text reading "Vous n'avez effectué aucun achat pour le moment."
**After:** A visually distinct empty state block matching other pages, with a dark "TROUVER DES ARTICLES" button leading to the dashboard.

### ♿ Accessibility
The CTA is an anchor tag (`<a>`) properly styled as a button using standard Tailwind classes, ensuring it remains focusable and semantically correct for keyboard and screen reader navigation.

---
*PR created automatically by Jules for task [14990783883074816361](https://jules.google.com/task/14990783883074816361) started by @Ganngann*