### PR TITLE
⚡ Bolt: Fix N+1 query issue in item image uploads

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -2,3 +2,7 @@
 **Learning:** Checking `Auth::user()->unreadNotifications->count()` inside the navigation layout triggers an N+1 query issue since notifications might not be loaded, and `count()` triggers a separate count query on the relation each time it's called (or loads all notifications). Actually, it loads the relation because it uses the property `unreadNotifications` and then calls `count()` on the collection. In this case, `unreadNotifications()->count()` is much more efficient as it performs an aggregate query, but even better is doing it right in a View Composer if needed, or just `unreadNotifications()->count()`. Wait, since it's `Auth::user()->unreadNotifications->count()`, it loads ALL unread notifications into memory just to count them!
 
 **Action:** Replace `$user->unreadNotifications->count()` with `$user->unreadNotifications()->count()`. This executes a simple `COUNT(*)` query without fetching the actual model records.
+
+## 2024-05-17 - [N+1 query in file upload loop]
+**Learning:** Using `$item->images()->count()` directly inside a loop that iterates over uploaded files causes an N+1 query issue. For every file being processed, the database is queried to recount the existing relationships, which degrades performance as the number of uploads increases.
+**Action:** When validating collection sizes or thresholds inside loops, pre-calculate the count outside the loop (e.g., `$currentCount = $model->relation()->count();`) and manually increment this local variable inside the loop (`$currentCount++`) instead of re-querying the database each time.

--- a/pifpaf/app/Http/Controllers/ItemController.php
+++ b/pifpaf/app/Http/Controllers/ItemController.php
@@ -406,9 +406,12 @@ class ItemController extends Controller
             // On récupère le dernier ordre pour continuer la séquence
             $order = $item->images()->max('order') + 1;
 
+            // ⚡ Bolt: Pre-calculate the image count outside the loop to avoid N+1 count queries
+            $currentImageCount = $item->images()->count();
+
             foreach ($request->file('images') as $imageFile) {
                 // On vérifie qu'on ne dépasse pas la limite totale de 10 images
-                if ($item->images()->count() >= 10) {
+                if ($currentImageCount >= 10) {
                     break;
                 }
 
@@ -417,6 +420,8 @@ class ItemController extends Controller
                     'path' => $path,
                     'order' => $order++,
                 ]);
+
+                $currentImageCount++;
             }
         }
 


### PR DESCRIPTION
💡 **What:** Replaced the `$item->images()->count()` method call inside the file upload loop in `ItemController.php` with a local `$currentImageCount` variable initialized before the loop and manually incremented inside.

🎯 **Why:** To prevent an N+1 performance bottleneck where a `SELECT COUNT(*)` query was being executed on the database during every iteration of the uploaded file processing loop to check the 10-image limit.

📊 **Impact:** Reduces database queries by O(N) where N is the number of files being uploaded, improving controller response time and decreasing database load.

🔬 **Measurement:** Verify by running test suite and monitoring database query execution during an item update with multiple file uploads. Wait time should scale constantly regardless of the number of uploaded images.

---
*PR created automatically by Jules for task [7428759976499914823](https://jules.google.com/task/7428759976499914823) started by @Ganngann*