### PR TITLE
⚡ Bolt: Fix N+1 query in item image upload loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -2,3 +2,7 @@
 **Learning:** Checking `Auth::user()->unreadNotifications->count()` inside the navigation layout triggers an N+1 query issue since notifications might not be loaded, and `count()` triggers a separate count query on the relation each time it's called (or loads all notifications). Actually, it loads the relation because it uses the property `unreadNotifications` and then calls `count()` on the collection. In this case, `unreadNotifications()->count()` is much more efficient as it performs an aggregate query, but even better is doing it right in a View Composer if needed, or just `unreadNotifications()->count()`. Wait, since it's `Auth::user()->unreadNotifications->count()`, it loads ALL unread notifications into memory just to count them!
 
 **Action:** Replace `$user->unreadNotifications->count()` with `$user->unreadNotifications()->count()`. This executes a simple `COUNT(*)` query without fetching the actual model records.
+
+## 2024-05-16 - [N+1 query in file upload loop]
+**Learning:** Executing a relation count query like `$item->images()->count()` inside a `foreach` loop for file uploads causes N+1 queries.
+**Action:** Pre-calculate the count outside the loop and increment a local variable inside the loop instead.

--- a/pifpaf/app/Http/Controllers/ItemController.php
+++ b/pifpaf/app/Http/Controllers/ItemController.php
@@ -405,10 +405,12 @@ class ItemController extends Controller
         if ($request->hasFile('images')) {
             // On récupère le dernier ordre pour continuer la séquence
             $order = $item->images()->max('order') + 1;
+            // Pre-calculate count outside the loop to avoid N+1 queries
+            $currentImageCount = $item->images()->count();
 
             foreach ($request->file('images') as $imageFile) {
                 // On vérifie qu'on ne dépasse pas la limite totale de 10 images
-                if ($item->images()->count() >= 10) {
+                if ($currentImageCount >= 10) {
                     break;
                 }
 
@@ -417,6 +419,7 @@ class ItemController extends Controller
                     'path' => $path,
                     'order' => $order++,
                 ]);
+                $currentImageCount++;
             }
         }
 


### PR DESCRIPTION
💡 What: Pre-calculate the image count outside the `foreach` loop for file uploads.
🎯 Why: Executing `$item->images()->count()` inside the loop triggers a separate SQL query for each uploaded image, causing an N+1 performance issue.
📊 Impact: Reduces database queries during image upload significantly (by N queries where N is the number of uploaded images).
🔬 Measurement: Verify by uploading multiple images and using a query logger to ensure only one count query is executed.

---
*PR created automatically by Jules for task [17315836829003497922](https://jules.google.com/task/17315836829003497922) started by @Ganngann*