### PR TITLE
⚡ Bolt: Optimize image upload N+1 query bottleneck

### DIFF
--- a/pifpaf/app/Http/Controllers/ItemController.php
+++ b/pifpaf/app/Http/Controllers/ItemController.php
@@ -406,9 +406,14 @@ class ItemController extends Controller
             // On récupère le dernier ordre pour continuer la séquence
             $order = $item->images()->max('order') + 1;
 
+            // ⚡ Bolt: Optimize N+1 query
+            // Pre-calculate the current image count before the loop to prevent
+            // a separate SELECT COUNT(*) database query on every iteration.
+            $currentImageCount = $item->images()->count();
+
             foreach ($request->file('images') as $imageFile) {
                 // On vérifie qu'on ne dépasse pas la limite totale de 10 images
-                if ($item->images()->count() >= 10) {
+                if ($currentImageCount >= 10) {
                     break;
                 }
 
@@ -417,6 +422,9 @@ class ItemController extends Controller
                     'path' => $path,
                     'order' => $order++,
                 ]);
+
+                // ⚡ Bolt: Manually increment the counter
+                $currentImageCount++;
             }
         }
 


### PR DESCRIPTION
💡 What: Extracted the `$item->images()->count()` query into a local variable before the image upload loop and incremented it manually.
🎯 Why: The original code executed a `SELECT COUNT(*)` query for every single uploaded image inside the loop, creating a significant N+1 query bottleneck when a user uploads multiple images.
📊 Impact: Reduces database queries during image uploads from N+1 (where N is the number of uploaded images) to just 1, leading to faster uploads and reduced database load.
🔬 Measurement: Run `php artisan test` (tests still pass) or monitor query counts in Laravel Telescope/debugbar during multiple image uploads to verify only a single aggregate count query is executed.

---
*PR created automatically by Jules for task [16286651841568168225](https://jules.google.com/task/16286651841568168225) started by @Ganngann*