### PR TITLE
🎨 Palette: Improve empty state for addresses

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-05-16 - Add ARIA Labels to Navigation Elements
 **Learning:** Icon-only links and toggle buttons (like the notifications bell and hamburger menu) are common in Laravel Breeze/Alpine navigation components but often lack accessible labels by default.
 **Action:** When adding or reviewing icon-only interactive elements, ensure `aria-label` is present. For elements that toggle state (like dropdowns or mobile menus), bind `aria-expanded` to the state variable (e.g., `:aria-expanded="open.toString()"` in Alpine.js) to communicate state to screen readers.
+
+## 2025-06-25 - Improve Empty States with Actionable CTAs
+**Learning:** Empty states without actionable buttons can lead to dead ends in the user flow. Wrapping the CTA directly inside the empty state component (`x-ui.empty-state`) significantly improves usability. However, keeping the main page-level CTA (e.g. "Add Address") visible when the empty state CTA is also present creates redundant and potentially confusing UI paths.
+**Action:** When replacing unstyled empty states with the `x-ui.empty-state` component and a CTA, conditionally hide any top-level 'Add' or 'Create' buttons to prevent confusing duplicate actions in the UI.

--- a/pifpaf/resources/views/profile/addresses/index.blade.php
+++ b/pifpaf/resources/views/profile/addresses/index.blade.php
@@ -11,12 +11,27 @@
                 <div class="p-6 bg-white border-b border-gray-200">
                     <div class="flex justify-between items-center mb-4">
                         <h3 class="text-lg font-semibold">Toutes mes adresses</h3>
-                        <a href="{{ route('profile.addresses.create') }}" class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 active:bg-gray-900 focus:outline-none focus:border-gray-900 focus:ring ring-gray-300 disabled:opacity-25 transition ease-in-out duration-150">
-                            Ajouter une adresse
-                        </a>
+                        @if($addresses->isNotEmpty())
+                            <a href="{{ route('profile.addresses.create') }}" class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 active:bg-gray-900 focus:outline-none focus:border-gray-900 focus:ring ring-gray-300 disabled:opacity-25 transition ease-in-out duration-150">
+                                Ajouter une adresse
+                            </a>
+                        @endif
                     </div>
                     @if($addresses->isEmpty())
-                        <p>Vous n'avez pas encore d'adresse enregistrée.</p>
+                        <x-ui.empty-state>
+                            <x-slot name="icon">
+                                <svg class="w-full h-full" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
+                                </svg>
+                            </x-slot>
+                            Vous n'avez pas encore d'adresse enregistrée.
+                            <x-slot name="actions">
+                                <a href="{{ route('profile.addresses.create') }}" class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 active:bg-gray-900 focus:outline-none focus:border-gray-900 focus:ring ring-gray-300 disabled:opacity-25 transition ease-in-out duration-150">
+                                    Ajouter une adresse
+                                </a>
+                            </x-slot>
+                        </x-ui.empty-state>
                     @else
                         <div class="space-y-4">
                             @foreach($addresses as $address)


### PR DESCRIPTION
💡 **What:** 
Replaced the plain text empty state ("Vous n'avez pas encore d'adresse enregistrée.") on the `/profile/addresses` page with the standard `<x-ui.empty-state>` component. This new empty state includes an icon and a direct call-to-action (CTA) to add an address. The page-level "Ajouter une adresse" button in the header is conditionally hidden when the address list is empty to prevent displaying two identical primary actions on the same page.

🎯 **Why:** 
Empty states without actionable buttons can create dead ends in the user flow, leaving users unsure of what to do next. Providing a direct CTA within the empty state provides a clearer, more immediate path forward. Conditionally hiding the page-level CTA when the empty state CTA is visible prevents confusion and maintains a clean, focused interface, guiding the user towards the single most important action.

📸 **Before/After:** 
Visual verification confirmed the new empty state displays correctly with the icon, descriptive text, and the "Ajouter une adresse" button centered within the container, while the top header CTA is hidden.

♿ **Accessibility:** 
The empty state utilizes existing `<x-ui.empty-state>` structure which ensures semantic consistency. The inline SVG icon includes `aria-hidden="true"` so it is ignored by screen readers, preventing redundant or confusing announcements, while the CTA remains fully keyboard navigable with appropriate focus states (inherited from existing button classes).

---
*PR created automatically by Jules for task [1606302852036103752](https://jules.google.com/task/1606302852036103752) started by @Ganngann*