### PR TITLE
⚡ Bolt: Prevent N+1 queries during item image upload

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -2,3 +2,7 @@
 **Learning:** Checking `Auth::user()->unreadNotifications->count()` inside the navigation layout triggers an N+1 query issue since notifications might not be loaded, and `count()` triggers a separate count query on the relation each time it's called (or loads all notifications). Actually, it loads the relation because it uses the property `unreadNotifications` and then calls `count()` on the collection. In this case, `unreadNotifications()->count()` is much more efficient as it performs an aggregate query, but even better is doing it right in a View Composer if needed, or just `unreadNotifications()->count()`. Wait, since it's `Auth::user()->unreadNotifications->count()`, it loads ALL unread notifications into memory just to count them!
 
 **Action:** Replace `$user->unreadNotifications->count()` with `$user->unreadNotifications()->count()`. This executes a simple `COUNT(*)` query without fetching the actual model records.
+
+## 2024-05-24 - [N+1 query in file upload loop]
+**Learning:** Calling `$item->images()->count()` inside a `foreach` loop creates a hidden N+1 query vulnerability because Laravel executes a `SELECT COUNT(*)` query on the database for every iteration.
+**Action:** Pre-calculate relational counts (like `$model->relation()->count()`) before the loop, store them in a local variable, and manually increment that variable inside the loop instead of re-executing the count query.

--- a/pifpaf/app/Http/Controllers/ItemController.php
+++ b/pifpaf/app/Http/Controllers/ItemController.php
@@ -406,9 +406,12 @@ class ItemController extends Controller
             // On récupère le dernier ordre pour continuer la séquence
             $order = $item->images()->max('order') + 1;
 
+            // BOLT OPTIMIZATION: Fetch count once before loop to prevent N+1 queries
+            $currentImageCount = $item->images()->count();
+
             foreach ($request->file('images') as $imageFile) {
                 // On vérifie qu'on ne dépasse pas la limite totale de 10 images
-                if ($item->images()->count() >= 10) {
+                if ($currentImageCount >= 10) {
                     break;
                 }
 
@@ -417,6 +420,8 @@ class ItemController extends Controller
                     'path' => $path,
                     'order' => $order++,
                 ]);
+
+                $currentImageCount++;
             }
         }
 


### PR DESCRIPTION
💡 What: Cached the image count before the loop to prevent repeated `count()` queries.
🎯 Why: Calculating `$item->images()->count()` inside a `foreach` loop creates an N+1 query bottleneck.
📊 Impact: Eliminates redundant database queries during multiple image uploads, reducing latency.
🔬 Measurement: Observe database query counts (using Telescope or clockwork) when uploading 5+ images simultaneously. They should decrease.

---
*PR created automatically by Jules for task [11090287736606870229](https://jules.google.com/task/11090287736606870229) started by @Ganngann*