### PR TITLE
🛡️ Sentinel: [HIGH] Fix IDOR in item images reordering

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,7 @@
 **Vulnerability:** The application had a critical path traversal vulnerability in `AiRequestController.php` and `ItemController.php` where user-controlled input (`image_path`, `original_image_path`) was passed directly to `Storage::disk('public')->path()` and `Storage::disk('public')->move()` without proper sanitization. This allowed attackers to potentially read or move arbitrary files on the server using `../../` sequences.
 **Learning:** Even when using Laravel's storage facade, unsanitized user input passed to methods like `path()`, `exists()`, or `move()` is unsafe. Path parameters received from external requests must be strictly validated.
 **Prevention:** Always validate file paths from external input using strict regex constraints (e.g., `regex:/^ai_images\/[a-zA-Z0-9_\-\.]+$/`) to ensure they only point to expected directories and do not contain directory traversal sequences.
+## 2025-06-26 - [Fix IDOR in bulk image reordering]
+**Vulnerability:** IDOR vulnerability in `ItemImageController@reorder` because authorization was only checked on the first ID in the provided array.
+**Learning:** Attackers could bypass authorization by placing their own resource ID at the start of the array and appending victim resource IDs.
+**Prevention:** Always verify authorization for every item when processing an array of IDs for bulk operations, and eager load relationships to avoid N+1 queries.

--- a/pifpaf/app/Http/Controllers/ItemImageController.php
+++ b/pifpaf/app/Http/Controllers/ItemImageController.php
@@ -69,8 +69,12 @@ class ItemImageController extends Controller
             'ids.*' => 'exists:item_images,id',
         ]);
 
-        $itemImage = ItemImage::find($request->ids[0]);
-        $this->authorize('update', $itemImage->item);
+        // Security fix: Validate authorization for every image in the array
+        // to prevent IDOR attacks using a mixed array of IDs.
+        $images = ItemImage::with('item')->whereIn('id', $request->ids)->get();
+        foreach ($images as $image) {
+            $this->authorize('update', $image->item);
+        }
 
         foreach ($request->ids as $index => $id) {
             ItemImage::where('id', $id)->update(['order' => $index]);

--- a/pifpaf/tests/Feature/ItemImageControllerTest.php
+++ b/pifpaf/tests/Feature/ItemImageControllerTest.php
@@ -128,4 +128,35 @@ class ItemImageControllerTest extends TestCase
         ]);
         $responseReorder->assertForbidden();
     }
+
+    public function test_user_cannot_reorder_other_users_images_with_mixed_array(): void
+    {
+        $attacker = User::factory()->create();
+        $victim = User::factory()->create();
+
+        $attackerItem = Item::factory()->create(['user_id' => $attacker->id]);
+        $victimItem = Item::factory()->create(['user_id' => $victim->id]);
+
+        $attackerImage = ItemImage::create([
+            'item_id' => $attackerItem->id,
+            'path' => 'fake_attacker.jpg',
+            'is_primary' => false,
+            'order' => 0,
+        ]);
+
+        $victimImage = ItemImage::create([
+            'item_id' => $victimItem->id,
+            'path' => 'fake_victim.jpg',
+            'is_primary' => false,
+            'order' => 0,
+        ]);
+
+        // Attempting to reorder victim's image by putting attacker's image ID first
+        // to bypass authorization check on the first element
+        $response = $this->actingAs($attacker)->postJson(route('item-images.reorder'), [
+            'ids' => [$attackerImage->id, $victimImage->id],
+        ]);
+
+        $response->assertForbidden();
+    }
 }


### PR DESCRIPTION
🚨 **Severity:** HIGH

💡 **Vulnerability:**
The `ItemImageController@reorder` method allowed for an Insecure Direct Object Reference (IDOR) bypass. When bulk reordering images via an array of IDs (`$request->ids`), the application only explicitly verified authorization on the *first* item in the array (`$request->ids[0]`). An attacker could provide a mixed array, starting with one of their own image IDs followed by victim image IDs, and bypass the security checks to reorder other users' images.

🎯 **Impact:**
An attacker could manipulate the display order of images on items that do not belong to them. While this is primarily an integrity issue (image ordering) rather than exposing sensitive data, the bypass mechanism itself demonstrates a significant authorization logic flaw for bulk operations.

🔧 **Fix:**
1. Modified the `ItemImageController@reorder` to fetch all image models corresponding to the provided IDs using eager loading (`with('item')` to prevent N+1 queries).
2. Placed the `$this->authorize('update', $image->item)` call inside a loop to strictly verify ownership/authorization for *every single image* within the requested array.
3. Added an explicit `test_user_cannot_reorder_other_users_images_with_mixed_array` test inside `ItemImageControllerTest.php` that actively attempts the mixed array exploit to prevent future regressions.

✅ **Verification:**
- `cd pifpaf && php artisan test --filter ItemImageControllerTest`
The `test_user_cannot_reorder_other_users_images_with_mixed_array` now returns a `403 Forbidden` response instead of passing successfully.

---
*PR created automatically by Jules for task [17430886852153226163](https://jules.google.com/task/17430886852153226163) started by @Ganngann*