### PR TITLE
🎨 Palette: Add CTAs to transaction empty states

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-05-16 - Add ARIA Labels to Navigation Elements
 **Learning:** Icon-only links and toggle buttons (like the notifications bell and hamburger menu) are common in Laravel Breeze/Alpine navigation components but often lack accessible labels by default.
 **Action:** When adding or reviewing icon-only interactive elements, ensure `aria-label` is present. For elements that toggle state (like dropdowns or mobile menus), bind `aria-expanded` to the state variable (e.g., `:aria-expanded="open.toString()"` in Alpine.js) to communicate state to screen readers.
+
+## 2026-05-17 - Add CTAs to Empty States
+**Learning:** Empty states without actionable next steps lead to dead ends and reduce user engagement, especially on primary transaction pages like "Mes Achats" or "Mes Ventes".
+**Action:** When implementing or updating empty states (e.g., using `x-ui.empty-state`), always include a relevant Call-To-Action (CTA) inside the `<x-slot name="actions">` (like "Browse items" or "Create listing") to guide the user to the next logical step. Use anchor tags styled as buttons for navigation.

--- a/pifpaf/resources/views/transactions/purchases.blade.php
+++ b/pifpaf/resources/views/transactions/purchases.blade.php
@@ -12,7 +12,14 @@
                     @forelse ($purchases as $transaction)
                         <x-purchase-card :transaction="$transaction" />
                     @empty
-                        <p>Vous n'avez effectué aucun achat pour le moment.</p>
+                        <x-ui.empty-state>
+                            Vous n'avez effectué aucun achat pour le moment.
+                            <x-slot name="actions">
+                                <a href="{{ route('welcome') }}" class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 active:bg-gray-900 focus:outline-none focus:border-gray-900 focus:ring ring-gray-300 disabled:opacity-25 transition ease-in-out duration-150">
+                                    Découvrir les articles
+                                </a>
+                            </x-slot>
+                        </x-ui.empty-state>
                     @endforelse
 
                     @if ($purchases->hasPages())

--- a/pifpaf/resources/views/transactions/sales.blade.php
+++ b/pifpaf/resources/views/transactions/sales.blade.php
@@ -16,6 +16,11 @@
                     @empty
                         <x-ui.empty-state>
                             Vous n'avez réalisé aucune vente pour le moment.
+                            <x-slot name="actions">
+                                <a href="{{ route('items.create') }}" class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 active:bg-gray-900 focus:outline-none focus:border-gray-900 focus:ring ring-gray-300 disabled:opacity-25 transition ease-in-out duration-150">
+                                    Créer une annonce
+                                </a>
+                            </x-slot>
                         </x-ui.empty-state>
                     @endforelse
 


### PR DESCRIPTION
### 💡 What
Added actionable Call-To-Action (CTA) buttons to the empty state screens on the "Mes Achats" and "Mes Ventes" pages. 
- The purchases page now links to the welcome/discovery page.
- The sales page now links directly to the item creation page.

### 🎯 Why
Empty states without next steps act as dead ends, confusing users and decreasing engagement. Providing clear, contextual actions guides the user on what to do next.

### 📸 Before/After
Before: The page just displayed text saying "Vous n'avez effectué aucun achat..."
After: A prominent primary button allows users to immediately start discovering or listing items.

### ♿ Accessibility
Used standard anchor links (`<a>`) styled as buttons for better semantic HTML navigation, ensuring screen readers and keyboard users can easily access the primary actions.

---
*PR created automatically by Jules for task [5376743701747273072](https://jules.google.com/task/5376743701747273072) started by @Ganngann*