### PR TITLE
⚡ Bolt: [performance improvement] Pre-calculate image count to prevent N+1 query

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -2,3 +2,7 @@
 **Learning:** Checking `Auth::user()->unreadNotifications->count()` inside the navigation layout triggers an N+1 query issue since notifications might not be loaded, and `count()` triggers a separate count query on the relation each time it's called (or loads all notifications). Actually, it loads the relation because it uses the property `unreadNotifications` and then calls `count()` on the collection. In this case, `unreadNotifications()->count()` is much more efficient as it performs an aggregate query, but even better is doing it right in a View Composer if needed, or just `unreadNotifications()->count()`. Wait, since it's `Auth::user()->unreadNotifications->count()`, it loads ALL unread notifications into memory just to count them!
 
 **Action:** Replace `$user->unreadNotifications->count()` with `$user->unreadNotifications()->count()`. This executes a simple `COUNT(*)` query without fetching the actual model records.
+
+## 2024-06-27 - [N+1 query in file upload loop]
+**Learning:** Checking `$item->images()->count()` inside a `foreach` loop (like during multiple file uploads) triggers an N+1 query issue, as the database is hit on every iteration to count the relations.
+**Action:** Pre-calculate relational counts (like `$model->relation()->count()`) outside the loop and manually increment the local variable inside, rather than executing `count()` on every iteration.

--- a/pifpaf/app/Http/Controllers/ItemController.php
+++ b/pifpaf/app/Http/Controllers/ItemController.php
@@ -406,9 +406,12 @@ class ItemController extends Controller
             // On récupère le dernier ordre pour continuer la séquence
             $order = $item->images()->max('order') + 1;
 
+            // ⚡ Bolt: Pre-calculate current image count outside the loop to prevent N+1 queries
+            $imageCount = $item->images()->count();
+
             foreach ($request->file('images') as $imageFile) {
                 // On vérifie qu'on ne dépasse pas la limite totale de 10 images
-                if ($item->images()->count() >= 10) {
+                if ($imageCount >= 10) {
                     break;
                 }
 
@@ -417,6 +420,9 @@ class ItemController extends Controller
                     'path' => $path,
                     'order' => $order++,
                 ]);
+
+                // ⚡ Bolt: Increment local counter instead of running another query
+                $imageCount++;
             }
         }
 


### PR DESCRIPTION
⚡ Bolt: [performance improvement]

**What:**
Pre-calculated the existing `$item->images()->count()` outside the `foreach` file upload loop in `ItemController.php` and incremented it locally.

**Why:**
The database was queried repeatedly inside the loop just to count the relations on every image upload iteration, causing an N+1 performance bottleneck.

**Impact:**
Reduces redundant database queries during multiple image uploads from O(N) to O(1).

**Measurement:**
Verified by running test suite and reviewing the code to ensure query is only run once before the loop.

---
*PR created automatically by Jules for task [7764866318519543953](https://jules.google.com/task/7764866318519543953) started by @Ganngann*