### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -2,3 +2,7 @@
 **Learning:** Checking `Auth::user()->unreadNotifications->count()` inside the navigation layout triggers an N+1 query issue since notifications might not be loaded, and `count()` triggers a separate count query on the relation each time it's called (or loads all notifications). Actually, it loads the relation because it uses the property `unreadNotifications` and then calls `count()` on the collection. In this case, `unreadNotifications()->count()` is much more efficient as it performs an aggregate query, but even better is doing it right in a View Composer if needed, or just `unreadNotifications()->count()`. Wait, since it's `Auth::user()->unreadNotifications->count()`, it loads ALL unread notifications into memory just to count them!
 
 **Action:** Replace `$user->unreadNotifications->count()` with `$user->unreadNotifications()->count()`. This executes a simple `COUNT(*)` query without fetching the actual model records.
+
+## 2025-11-10 - [N+1 query in file upload loop]
+**Learning:** Using `$model->relation()->count()` inside a `foreach` loop (like when uploading multiple files) triggers a new database query on every iteration to count the relations.
+**Action:** Pre-calculate relational counts (e.g., `$count = $model->relation()->count();`) outside the loop and manually increment the local variable inside to prevent N+1 query performance issues.

--- a/pifpaf/app/Http/Controllers/ItemController.php
+++ b/pifpaf/app/Http/Controllers/ItemController.php
@@ -406,9 +406,12 @@ class ItemController extends Controller
             // On récupère le dernier ordre pour continuer la séquence
             $order = $item->images()->max('order') + 1;
 
+            // ⚡ Bolt: Cache image count to prevent N+1 query inside the loop
+            $currentImageCount = $item->images()->count();
+
             foreach ($request->file('images') as $imageFile) {
                 // On vérifie qu'on ne dépasse pas la limite totale de 10 images
-                if ($item->images()->count() >= 10) {
+                if ($currentImageCount >= 10) {
                     break;
                 }
 
@@ -417,6 +420,7 @@ class ItemController extends Controller
                     'path' => $path,
                     'order' => $order++,
                 ]);
+                $currentImageCount++;
             }
         }
 


### PR DESCRIPTION
💡 What: Extracted the `$item->images()->count()` call out of the `foreach` loop when uploading multiple files in `ItemController@update`, caching it in a local variable `$currentImageCount` that increments.

🎯 Why: Calling `$item->images()->count()` inside the loop triggers a separate SQL query on every single iteration to evaluate the maximum file limit. By moving it out, we avoid N+1 queries.

📊 Impact: Reduces database count queries during multi-file item uploads by up to 10 queries, lowering execution time and database load.

🔬 Measurement: I ran a local benchmark script comparing the loop execution with the query inside vs. outside. The optimization eliminates redundant N+1 aggregate queries, providing a measurable reduction in DB operations. Tests passed successfully.

---
*PR created automatically by Jules for task [15990284028941010201](https://jules.google.com/task/15990284028941010201) started by @Ganngann*