### PR TITLE
⚡ Bolt: Fix N+1 query issue during image upload

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -2,3 +2,7 @@
 **Learning:** Checking `Auth::user()->unreadNotifications->count()` inside the navigation layout triggers an N+1 query issue since notifications might not be loaded, and `count()` triggers a separate count query on the relation each time it's called (or loads all notifications). Actually, it loads the relation because it uses the property `unreadNotifications` and then calls `count()` on the collection. In this case, `unreadNotifications()->count()` is much more efficient as it performs an aggregate query, but even better is doing it right in a View Composer if needed, or just `unreadNotifications()->count()`. Wait, since it's `Auth::user()->unreadNotifications->count()`, it loads ALL unread notifications into memory just to count them!
 
 **Action:** Replace `$user->unreadNotifications->count()` with `$user->unreadNotifications()->count()`. This executes a simple `COUNT(*)` query without fetching the actual model records.
+
+## 2024-05-18 - [N+1 query in image upload loop]
+**Learning:** Checking `$item->images()->count()` inside a `foreach` loop processing file uploads executes a `SELECT COUNT(*)` database query on every iteration, leading to an N+1 performance issue.
+**Action:** Pre-calculate the count outside the loop (`$count = $item->images()->count();`) and manually increment a local variable inside the loop (`$count++`) instead of re-querying the database.

--- a/pifpaf/app/Http/Controllers/ItemController.php
+++ b/pifpaf/app/Http/Controllers/ItemController.php
@@ -406,9 +406,12 @@ class ItemController extends Controller
             // On récupère le dernier ordre pour continuer la séquence
             $order = $item->images()->max('order') + 1;
 
+            // ⚡ Bolt: Prevent N+1 query issue by pre-calculating the count outside the loop.
+            $currentImageCount = $item->images()->count();
+
             foreach ($request->file('images') as $imageFile) {
                 // On vérifie qu'on ne dépasse pas la limite totale de 10 images
-                if ($item->images()->count() >= 10) {
+                if ($currentImageCount >= 10) {
                     break;
                 }
 
@@ -417,6 +420,8 @@ class ItemController extends Controller
                     'path' => $path,
                     'order' => $order++,
                 ]);
+
+                $currentImageCount++;
             }
         }
 


### PR DESCRIPTION
💡 What: Replaced the dynamic `$item->images()->count()` database query inside the image upload `foreach` loop with a pre-calculated local variable that is manually incremented.

🎯 Why: To prevent an N+1 performance bottleneck. Previously, if a user uploaded 10 images simultaneously, the application would execute 10 separate `SELECT COUNT(*)` queries against the database just to enforce the 10-image limit. 

📊 Impact: Reduces the number of database queries during image uploads from O(N) to O(1) regarding the count verification, saving up to 9 unnecessary queries per upload batch.

🔬 Measurement: Verify by executing an image upload with multiple files and observing the database query logs. The `SELECT count(*) FROM item_images WHERE item_id = ?` query will now only execute once per request instead of multiple times.

---
*PR created automatically by Jules for task [11046015458981686939](https://jules.google.com/task/11046015458981686939) started by @Ganngann*