### PR TITLE
⚡ Bolt: [performance improvement] fix n+1 queries inside image upload loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -2,3 +2,7 @@
 **Learning:** Checking `Auth::user()->unreadNotifications->count()` inside the navigation layout triggers an N+1 query issue since notifications might not be loaded, and `count()` triggers a separate count query on the relation each time it's called (or loads all notifications). Actually, it loads the relation because it uses the property `unreadNotifications` and then calls `count()` on the collection. In this case, `unreadNotifications()->count()` is much more efficient as it performs an aggregate query, but even better is doing it right in a View Composer if needed, or just `unreadNotifications()->count()`. Wait, since it's `Auth::user()->unreadNotifications->count()`, it loads ALL unread notifications into memory just to count them!
 
 **Action:** Replace `$user->unreadNotifications->count()` with `$user->unreadNotifications()->count()`. This executes a simple `COUNT(*)` query without fetching the actual model records.
+
+## 2025-02-12 - [N+1 Database query inside a loop in ItemController]
+**Learning:** Calling `$item->images()->count()` inside a `foreach` loop that iterates over uploaded files causes an N+1 query problem, as it queries the database on every iteration.
+**Action:** Pre-calculate the current image count outside the loop using `$currentImageCount = $item->images()->count();` and then increment this local variable inside the loop (`$currentImageCount++`).

--- a/pifpaf/app/Http/Controllers/ItemController.php
+++ b/pifpaf/app/Http/Controllers/ItemController.php
@@ -406,9 +406,12 @@ class ItemController extends Controller
             // On récupère le dernier ordre pour continuer la séquence
             $order = $item->images()->max('order') + 1;
 
+            // ⚡ Bolt: Prevent N+1 queries by pre-calculating count outside loop
+            $currentImageCount = $item->images()->count();
+
             foreach ($request->file('images') as $imageFile) {
                 // On vérifie qu'on ne dépasse pas la limite totale de 10 images
-                if ($item->images()->count() >= 10) {
+                if ($currentImageCount >= 10) {
                     break;
                 }
 
@@ -417,6 +420,7 @@ class ItemController extends Controller
                     'path' => $path,
                     'order' => $order++,
                 ]);
+                $currentImageCount++;
             }
         }
 


### PR DESCRIPTION
* 💡 **What**: Pre-calculated the number of images an item has outside of the image upload processing `foreach` loop instead of evaluating it dynamically per image on every iteration. 
* 🎯 **Why**: When uploading files, calling `$item->images()->count()` sequentially in the loop caused an N+1 performance bottleneck where the database executes an aggregate count query for every file uploaded instead of just once per request.
* 📊 **Impact**: Prevents redundant database queries during image uploads (saving up to 10 duplicate count queries per batch upload request), saving resources and execution time.
* 🔬 **Measurement**: Check the `update` method in `app/Http/Controllers/ItemController.php` to see that `count()` is calculated once outside of the `foreach ($request->file('images') as $imageFile)` loop.

---
*PR created automatically by Jules for task [18445138767942067592](https://jules.google.com/task/18445138767942067592) started by @Ganngann*