### PR TITLE
🛡️ Sentinel: [HIGH] Fix IDOR in address assignment

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,7 @@
 **Vulnerability:** The application had a critical path traversal vulnerability in `AiRequestController.php` and `ItemController.php` where user-controlled input (`image_path`, `original_image_path`) was passed directly to `Storage::disk('public')->path()` and `Storage::disk('public')->move()` without proper sanitization. This allowed attackers to potentially read or move arbitrary files on the server using `../../` sequences.
 **Learning:** Even when using Laravel's storage facade, unsanitized user input passed to methods like `path()`, `exists()`, or `move()` is unsafe. Path parameters received from external requests must be strictly validated.
 **Prevention:** Always validate file paths from external input using strict regex constraints (e.g., `regex:/^ai_images\/[a-zA-Z0-9_\-\.]+$/`) to ensure they only point to expected directories and do not contain directory traversal sequences.
+## 2025-05-20 - [Fix IDOR in ItemController address assignment]
+**Vulnerability:** A mass assignment/IDOR vulnerability existed in `ItemController.php` where `address_id` was validated only with `exists:addresses,id`. This allowed a malicious user to assign another user's address to their item.
+**Learning:** `exists` checks only if the record exists in the database table, without checking authorization. For references to user-owned models like addresses, validation must be scoped.
+**Prevention:** Always use `Rule::exists('table', 'id')->where('user_id', Auth::id())` to ensure foreign keys assigned from user input belong to the authenticated user.

--- a/pifpaf/app/Http/Controllers/ItemController.php
+++ b/pifpaf/app/Http/Controllers/ItemController.php
@@ -15,6 +15,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
 use Intervention\Image\ImageManager;
 use Intervention\Image\Drivers\Gd\Driver;
+use Illuminate\Validation\Rule;
 
 class ItemController extends Controller
 {
@@ -306,7 +307,12 @@ class ItemController extends Controller
             'image_path' => ['sometimes', 'string', 'regex:/^ai_images\/[a-zA-Z0-9_\-\.]+$/'],
             'delivery_available' => 'sometimes|boolean',
             'pickup_available' => 'sometimes|boolean',
-            'address_id' => 'required_if:pickup_available,true|nullable|exists:addresses,id',
+            'address_id' => [
+                'required_if:pickup_available,true',
+                'nullable',
+                // Security: Prevent IDOR by ensuring the user can only use their own addresses
+                Rule::exists('addresses', 'id')->where('user_id', Auth::id()),
+            ],
             'weight' => 'required_if:delivery_available,true|nullable|numeric|min:1',
             'length' => 'required_if:delivery_available,true|nullable|numeric|min:1',
             'width' => 'required_if:delivery_available,true|nullable|numeric|min:1',
@@ -387,7 +393,12 @@ class ItemController extends Controller
             'images.*' => 'image|mimes:jpeg,png,jpg|max:2048',
             'delivery_available' => 'sometimes|boolean',
             'pickup_available' => 'sometimes|boolean',
-            'address_id' => 'required_if:pickup_available,true|nullable|exists:addresses,id',
+            'address_id' => [
+                'required_if:pickup_available,true',
+                'nullable',
+                // Security: Prevent IDOR by ensuring the user can only use their own addresses
+                Rule::exists('addresses', 'id')->where('user_id', Auth::id()),
+            ],
             'weight' => 'required_if:delivery_available,true|nullable|numeric|min:1',
             'length' => 'required_if:delivery_available,true|nullable|numeric|min:1',
             'width' => 'required_if:delivery_available,true|nullable|numeric|min:1',


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Mass assignment / Insecure Direct Object Reference (IDOR) existed in `ItemController.php` for the `address_id` field. An attacker could use any valid `address_id` (even belonging to another user) to create or update their own item.
🎯 **Impact:** Allowed malicious users to associate items with arbitrary addresses they did not own.
🔧 **Fix:** Replaced the simple `exists:addresses,id` rule with `Rule::exists('addresses', 'id')->where('user_id', Auth::id())` to restrict the input strictly to the authenticated user's addresses.
✅ **Verification:** Verified that tests pass, including new potential edge cases, and that the validation correctly restricts inputs to user-owned addresses. Recorded finding in Sentinel journal.

---
*PR created automatically by Jules for task [12354845797823418782](https://jules.google.com/task/12354845797823418782) started by @Ganngann*