### PR TITLE
⚡ Bolt: [performance improvement] Prevent N+1 query during image upload

### DIFF
--- a/pifpaf/app/Http/Controllers/ItemController.php
+++ b/pifpaf/app/Http/Controllers/ItemController.php
@@ -406,9 +406,12 @@ class ItemController extends Controller
             // On récupère le dernier ordre pour continuer la séquence
             $order = $item->images()->max('order') + 1;
 
+            // Optimization: Pre-calculate count to prevent N+1 query inside the loop
+            $imageCount = $item->images()->count();
+
             foreach ($request->file('images') as $imageFile) {
                 // On vérifie qu'on ne dépasse pas la limite totale de 10 images
-                if ($item->images()->count() >= 10) {
+                if ($imageCount >= 10) {
                     break;
                 }
 
@@ -417,6 +420,7 @@ class ItemController extends Controller
                     'path' => $path,
                     'order' => $order++,
                 ]);
+                $imageCount++;
             }
         }
 


### PR DESCRIPTION
💡 What: The optimization implements a pre-calculation of the `$item->images()->count()` outside the `foreach` loop during image upload processing in `ItemController::update`. It stores the count in a local variable `$imageCount` and manually increments it after each new image is created.
🎯 Why: Previously, `$item->images()->count()` was evaluated inside the loop, causing a separate `SELECT COUNT(*)` database query to execute on every iteration. This created an N+1 query bottleneck when uploading multiple images.
📊 Impact: Reduces redundant database count queries during image uploads from `N` queries to `1` query, where `N` is the number of uploaded images.
🔬 Measurement: Verify the improvement by running a profiling tool (e.g., Laravel Debugbar or Telescope) during a multiple-image upload request to the `update` endpoint and observing the reduction in executed database queries. All unit and feature tests related to item image uploads continue to pass successfully.

---
*PR created automatically by Jules for task [9198185556741170760](https://jules.google.com/task/9198185556741170760) started by @Ganngann*