### PR TITLE
🛡️ Sentinel: [HIGH] Fix IDOR in Item Address Assignment

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,7 @@
 **Vulnerability:** The application had a critical path traversal vulnerability in `AiRequestController.php` and `ItemController.php` where user-controlled input (`image_path`, `original_image_path`) was passed directly to `Storage::disk('public')->path()` and `Storage::disk('public')->move()` without proper sanitization. This allowed attackers to potentially read or move arbitrary files on the server using `../../` sequences.
 **Learning:** Even when using Laravel's storage facade, unsanitized user input passed to methods like `path()`, `exists()`, or `move()` is unsafe. Path parameters received from external requests must be strictly validated.
 **Prevention:** Always validate file paths from external input using strict regex constraints (e.g., `regex:/^ai_images\/[a-zA-Z0-9_\-\.]+$/`) to ensure they only point to expected directories and do not contain directory traversal sequences.
+## 2026-07-03 - [Fix IDOR Vulnerability in ItemController Address Assignment]
+**Vulnerability:** An IDOR vulnerability existed in `ItemController@store` and `ItemController@update` where users could assign any existing `address_id` to their items, even if the address belonged to another user.
+**Learning:** Relying solely on `exists:addresses,id` validation rule for foreign keys is insufficient when the resource belongs to a specific user.
+**Prevention:** Always scope `exists` validation rules using `Rule::exists('table', 'id')->where('user_id', Auth::id())` to ensure the referenced resource belongs to the authenticated user.

--- a/pifpaf/app/Http/Controllers/ItemController.php
+++ b/pifpaf/app/Http/Controllers/ItemController.php
@@ -13,6 +13,7 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Validation\Rule;
 use Intervention\Image\ImageManager;
 use Intervention\Image\Drivers\Gd\Driver;
 
@@ -306,7 +307,11 @@ class ItemController extends Controller
             'image_path' => ['sometimes', 'string', 'regex:/^ai_images\/[a-zA-Z0-9_\-\.]+$/'],
             'delivery_available' => 'sometimes|boolean',
             'pickup_available' => 'sometimes|boolean',
-            'address_id' => 'required_if:pickup_available,true|nullable|exists:addresses,id',
+            'address_id' => [
+                'required_if:pickup_available,true',
+                'nullable',
+                Rule::exists('addresses', 'id')->where('user_id', Auth::id()),
+            ],
             'weight' => 'required_if:delivery_available,true|nullable|numeric|min:1',
             'length' => 'required_if:delivery_available,true|nullable|numeric|min:1',
             'width' => 'required_if:delivery_available,true|nullable|numeric|min:1',
@@ -387,7 +392,11 @@ class ItemController extends Controller
             'images.*' => 'image|mimes:jpeg,png,jpg|max:2048',
             'delivery_available' => 'sometimes|boolean',
             'pickup_available' => 'sometimes|boolean',
-            'address_id' => 'required_if:pickup_available,true|nullable|exists:addresses,id',
+            'address_id' => [
+                'required_if:pickup_available,true',
+                'nullable',
+                Rule::exists('addresses', 'id')->where('user_id', Auth::id()),
+            ],
             'weight' => 'required_if:delivery_available,true|nullable|numeric|min:1',
             'length' => 'required_if:delivery_available,true|nullable|numeric|min:1',
             'width' => 'required_if:delivery_available,true|nullable|numeric|min:1',

--- a/pifpaf/tests/Feature/ItemIdorTest.php
+++ b/pifpaf/tests/Feature/ItemIdorTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Address;
+use App\Models\Item;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class ItemIdorTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function user_cannot_assign_others_address_to_their_item()
+    {
+        Storage::fake('public');
+
+        $user1 = User::factory()->create();
+        $user2 = User::factory()->create();
+
+        $addressUser2 = Address::factory()->create([
+            'user_id' => $user2->id,
+            'is_for_pickup' => true,
+        ]);
+
+        $response = $this->actingAs($user1)->post(route('items.store'), [
+            'title' => 'Test Item',
+            'description' => 'Test Description',
+            'category' => 'Autre',
+            'price' => 10,
+            'pickup_available' => true,
+            'address_id' => $addressUser2->id,
+            'images' => [UploadedFile::fake()->image('image.jpg')],
+        ]);
+
+        $response->assertSessionHasErrors('address_id');
+        $this->assertDatabaseMissing('items', [
+            'user_id' => $user1->id,
+            'address_id' => $addressUser2->id,
+        ]);
+    }
+
+    #[Test]
+    public function user_cannot_assign_others_address_when_updating_item()
+    {
+        Storage::fake('public');
+
+        $user1 = User::factory()->create();
+        $user2 = User::factory()->create();
+
+        $item = Item::factory()->create([
+            'user_id' => $user1->id,
+        ]);
+
+        $addressUser2 = Address::factory()->create([
+            'user_id' => $user2->id,
+            'is_for_pickup' => true,
+        ]);
+
+        $response = $this->actingAs($user1)->put(route('items.update', $item), [
+            'title' => 'Updated Item',
+            'description' => 'Updated Description',
+            'category' => 'Autre',
+            'price' => 20,
+            'pickup_available' => true,
+            'address_id' => $addressUser2->id,
+        ]);
+
+        $response->assertSessionHasErrors('address_id');
+        $this->assertDatabaseMissing('items', [
+            'id' => $item->id,
+            'address_id' => $addressUser2->id,
+        ]);
+    }
+}


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Users could assign an arbitrary existing `address_id` to their Items during creation (`store`) or modification (`update`). The validation rule `exists:addresses,id` did not check if the address actually belonged to the authenticated user.
🎯 Impact: This Insecure Direct Object Reference (IDOR) could allow users to map their items to pickup addresses belonging to other users.
🔧 Fix: Updated the validation rules in `ItemController@store` and `ItemController@update` to use `Rule::exists('addresses', 'id')->where('user_id', Auth::id())`, ensuring the address ID exists and belongs to the current user.
✅ Verification: Covered by the `ItemIdorTest` (tests `user_cannot_assign_others_address_to_their_item` and `user_cannot_assign_others_address_when_updating_item`), which now passes. The full test suite has also been executed locally to verify no regressions were introduced.

---
*PR created automatically by Jules for task [17512377989731028697](https://jules.google.com/task/17512377989731028697) started by @Ganngann*