### PR TITLE
⚡ Bolt: [performance improvement] Optimize image count DB queries during upload

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -2,3 +2,7 @@
 **Learning:** Checking `Auth::user()->unreadNotifications->count()` inside the navigation layout triggers an N+1 query issue since notifications might not be loaded, and `count()` triggers a separate count query on the relation each time it's called (or loads all notifications). Actually, it loads the relation because it uses the property `unreadNotifications` and then calls `count()` on the collection. In this case, `unreadNotifications()->count()` is much more efficient as it performs an aggregate query, but even better is doing it right in a View Composer if needed, or just `unreadNotifications()->count()`. Wait, since it's `Auth::user()->unreadNotifications->count()`, it loads ALL unread notifications into memory just to count them!
 
 **Action:** Replace `$user->unreadNotifications->count()` with `$user->unreadNotifications()->count()`. This executes a simple `COUNT(*)` query without fetching the actual model records.
+
+## 2026-07-03 - [N+1 query in image upload loop]
+**Learning:** Using `$item->images()->count()` inside a `foreach` loop for file uploads causes an N+1 DB query problem because Laravel executes a `SELECT COUNT(*)` for every single image processed, creating an unnecessary DB bottleneck when saving multiple files.
+**Action:** Pre-calculate the relationship count outside the loop (`$count = $model->relation()->count();`) and manually increment the local variable inside the loop.

--- a/pifpaf/app/Http/Controllers/ItemController.php
+++ b/pifpaf/app/Http/Controllers/ItemController.php
@@ -406,9 +406,12 @@ class ItemController extends Controller
             // On récupère le dernier ordre pour continuer la séquence
             $order = $item->images()->max('order') + 1;
 
+            // ⚡ Bolt: Pré-calcul du nombre d'images pour éviter une requête N+1 dans la boucle
+            $imageCount = $item->images()->count();
+
             foreach ($request->file('images') as $imageFile) {
                 // On vérifie qu'on ne dépasse pas la limite totale de 10 images
-                if ($item->images()->count() >= 10) {
+                if ($imageCount >= 10) {
                     break;
                 }
 
@@ -417,6 +420,7 @@ class ItemController extends Controller
                     'path' => $path,
                     'order' => $order++,
                 ]);
+                $imageCount++;
             }
         }
 


### PR DESCRIPTION
💡 What: The `$item->images()->count()` logic inside the image upload `foreach` loop in `ItemController@update` has been moved outside the loop and the count is tracked via a local variable instead.
🎯 Why: Calling `$item->images()->count()` inside a loop executes a new database query (`SELECT COUNT(*)`) on each iteration. By storing it outside and incrementing it, we avoid N+1 DB queries during image upload, making the save operation faster.
📊 Impact: Reduces database queries when a user uploads multiple images (up to 10 queries eliminated).
🔬 Measurement: Verify by executing `php artisan test --filter ItemControllerTest` to ensure uploads still correctly enforce the 10-image maximum limit without regressions.

---
*PR created automatically by Jules for task [5709880244092974670](https://jules.google.com/task/5709880244092974670) started by @Ganngann*