### PR TITLE
⚡ Bolt: [performance improvement] Fix N+1 query in Item image upload limit check

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -2,3 +2,7 @@
 **Learning:** Checking `Auth::user()->unreadNotifications->count()` inside the navigation layout triggers an N+1 query issue since notifications might not be loaded, and `count()` triggers a separate count query on the relation each time it's called (or loads all notifications). Actually, it loads the relation because it uses the property `unreadNotifications` and then calls `count()` on the collection. In this case, `unreadNotifications()->count()` is much more efficient as it performs an aggregate query, but even better is doing it right in a View Composer if needed, or just `unreadNotifications()->count()`. Wait, since it's `Auth::user()->unreadNotifications->count()`, it loads ALL unread notifications into memory just to count them!
 
 **Action:** Replace `$user->unreadNotifications->count()` with `$user->unreadNotifications()->count()`. This executes a simple `COUNT(*)` query without fetching the actual model records.
+
+## 2026-07-04 - N+1 query in file upload loops
+**Learning:** Calling `$item->images()->count()` inside a `foreach` loop for file uploads executes a COUNT query on every iteration, leading to an N+1 query performance issue.
+**Action:** Pre-calculate relational counts outside the loop and manually increment the local variable inside to prevent repeated database queries.

--- a/pifpaf/app/Http/Controllers/ItemController.php
+++ b/pifpaf/app/Http/Controllers/ItemController.php
@@ -406,9 +406,12 @@ class ItemController extends Controller
             // On récupère le dernier ordre pour continuer la séquence
             $order = $item->images()->max('order') + 1;
 
+            // ⚡ Bolt: Pre-calculate count outside the loop to prevent N+1 query issue
+            $currentImageCount = $item->images()->count();
+
             foreach ($request->file('images') as $imageFile) {
                 // On vérifie qu'on ne dépasse pas la limite totale de 10 images
-                if ($item->images()->count() >= 10) {
+                if ($currentImageCount >= 10) {
                     break;
                 }
 
@@ -417,6 +420,7 @@ class ItemController extends Controller
                     'path' => $path,
                     'order' => $order++,
                 ]);
+                $currentImageCount++;
             }
         }
 


### PR DESCRIPTION
💡 **What:** Refactored the `update` method in `ItemController` to pre-calculate the image count outside the `foreach` upload loop, storing it in `$currentImageCount` and manually incrementing it inside.

🎯 **Why:** Previously, `$item->images()->count()` was called inside the loop, executing a new database COUNT query on every iteration for every uploaded image, leading to an N+1 performance issue.

📊 **Impact:** Reduces database queries by `N` during image uploads (where N is the number of images being uploaded).

🔬 **Measurement:** Verify by running Laravel Telescope, DB query logger, or observing the reduced query execution count when uploading multiple images simultaneously. The unit tests continue to pass and `ItemController` limits images correctly to a maximum of 10.

---
*PR created automatically by Jules for task [8554721038636714151](https://jules.google.com/task/8554721038636714151) started by @Ganngann*