### PR TITLE
🎨 Palette: [a11y] Add ARIA attributes to AI request toggles

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-07-05 - Use semantic buttons for toggles
+**Learning:** Interactive accordion headers built with Alpine.js often use `<div>` elements with `@click` handlers, making them inaccessible to keyboard users and screen readers.
+**Action:** Always replace clickable `<div>` elements with `<button type="button">`, and ensure they include `:aria-expanded` and keyboard focus styles (e.g., `focus:ring-2`).

--- a/pifpaf/resources/views/ai-requests/index.blade.php
+++ b/pifpaf/resources/views/ai-requests/index.blade.php
@@ -22,7 +22,7 @@
 
                     @forelse ($requests as $request)
                         <div class="mb-6 p-4 border rounded-lg shadow-sm" x-data="{ open: false }" dusk="ai-request-{{ $request->id }}">
-                            <div class="flex justify-between items-center cursor-pointer" @click="open = !open" dusk="ai-request-header-{{ $request->id }}">
+                            <button type="button" class="w-full flex justify-between items-center cursor-pointer text-left focus:outline-none focus:ring-2 focus:ring-blue-500 rounded-md" @click="open = !open" :aria-expanded="open.toString()" aria-label="Détails de la demande du {{ $request->created_at->format('d/m/Y à H:i') }}" dusk="ai-request-header-{{ $request->id }}">
                                 <div class="flex items-center">
                                     <img src="{{ asset('storage/' . $request->image_path) }}" alt="Image analysée" class="w-16 h-16 object-cover rounded-lg mr-4">
                                     <div>
@@ -36,7 +36,7 @@
                                     </div>
                                 </div>
                                 <div x-text="open ? '-' : '+'" class="text-2xl font-bold"></div>
-                            </div>
+                            </button>
 
                             <div x-show="open" class="mt-4">
                                 @if ($request->status === 'completed')
@@ -215,7 +215,7 @@
                                             <p class="text-red-500">{{ $request->error_message }}</p>
                                             <div class="flex items-center space-x-2">
                                                 @if ($request->raw_error_response)
-                                                    <button @click="showDetails = !showDetails" class="text-sm text-blue-500 hover:underline">
+                                                    <button type="button" @click="showDetails = !showDetails" :aria-expanded="showDetails.toString()" class="text-sm text-blue-500 hover:underline focus:outline-none focus:ring-2 focus:ring-blue-500 rounded-md">
                                                         <span x-show="!showDetails">Voir les détails</span>
                                                         <span x-show="showDetails">Cacher les détails</span>
                                                     </button>


### PR DESCRIPTION
**💡 What:**
Replaced the `<div>` used as a toggle for AI request details with a semantic `<button>` and added proper focus styling. Also added `aria-expanded` attributes to both the main request toggle and the error details toggle to correctly communicate their state.

**🎯 Why:**
Clickable `<div>` elements are inaccessible to keyboard users as they cannot receive focus, and without `aria-expanded` attributes, screen readers cannot determine if an accordion is open or closed.

**📸 Before/After:**
*(See visual verification)*

**♿ Accessibility:**
- Main toggle is now a `<button>` (focusable and operable via keyboard).
- Added `focus:ring-2 focus:ring-blue-500` to make keyboard focus visible.
- Bound `:aria-expanded` to Alpine.js state for screen readers.

---
*PR created automatically by Jules for task [9762755970031435896](https://jules.google.com/task/9762755970031435896) started by @Ganngann*