### PR TITLE
🎨 Palette: Add aria-label and aria-haspopup to user navigation menu

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-05-16 - Add ARIA Labels to Navigation Elements
 **Learning:** Icon-only links and toggle buttons (like the notifications bell and hamburger menu) are common in Laravel Breeze/Alpine navigation components but often lack accessible labels by default.
 **Action:** When adding or reviewing icon-only interactive elements, ensure `aria-label` is present. For elements that toggle state (like dropdowns or mobile menus), bind `aria-expanded` to the state variable (e.g., `:aria-expanded="open.toString()"` in Alpine.js) to communicate state to screen readers.
+
+## 2026-07-07 - Add ARIA Labels to User Menu Toggles
+**Learning:** Even when a toggle button contains text (like a user's name), if it functions as a dropdown menu toggle, it may benefit from an explicit `aria-label` (e.g., "Menu utilisateur") to clearly describe its primary action to screen reader users, beyond just the visible text.
+**Action:** When reviewing navigation dropdowns or setting menus, ensure the toggle element explicitly communicates its menu function via `aria-label` or `aria-haspopup`.

--- a/pifpaf/resources/views/layouts/navigation.blade.php
+++ b/pifpaf/resources/views/layouts/navigation.blade.php
@@ -41,7 +41,7 @@
 
                     <!-- Settings Dropdown -->
                     <div class="relative z-50" x-data="{ open: false }">
-                        <button @click="open = ! open" dusk="nav-user-dropdown" :aria-expanded="open.toString()" class="flex items-center text-sm font-medium text-gray-500 hover:text-gray-700 hover:border-gray-300 focus:outline-none focus:text-gray-700 focus:border-gray-300 transition duration-150 ease-in-out">
+                        <button @click="open = ! open" dusk="nav-user-dropdown" aria-haspopup="menu" aria-label="Menu utilisateur, {{ Auth::user()->name }}" :aria-expanded="open.toString()" class="flex items-center text-sm font-medium text-gray-500 hover:text-gray-700 hover:border-gray-300 focus:outline-none focus:text-gray-700 focus:border-gray-300 transition duration-150 ease-in-out">
                             <div>{{ Auth::user()->name }}</div>
 
                             <div class="ml-1">


### PR DESCRIPTION
* 💡 What: Added `aria-haspopup="menu"` and `aria-label="Menu utilisateur, {{ Auth::user()->name }}"` to the user dropdown menu button in the main navigation.
* 🎯 Why: To explicitly communicate to screen reader users that the button toggles a menu, and to provide context that it's a "User menu", while preserving the visible username text as required by WCAG 2.5.3 (Label in Name).
* ♿ Accessibility: Improves screen reader experience by correctly identifying the element as a menu toggle and preserving the accessible name consistency.

---
*PR created automatically by Jules for task [4850183888420851339](https://jules.google.com/task/4850183888420851339) started by @Ganngann*