### PR TITLE
🎨 Palette: Improve accessibility of gallery image thumbnails

### DIFF
--- a/pifpaf/.Jules/palette.md
+++ b/pifpaf/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-07-13 - Gallery Thumbnail Accessibility
+**Learning:** Icon-only or image-only interactive elements like gallery thumbnails (<button>) require explicit aria-labels, even if the inner <img> has an alt attribute, to clarify the interaction purpose for screen readers.
+**Action:** Add descriptive aria-labels to all image-only buttons to explain what activating the button will do (e.g., "View full image").

--- a/pifpaf/resources/views/components/items/gallery.blade.php
+++ b/pifpaf/resources/views/components/items/gallery.blade.php
@@ -20,6 +20,7 @@
                         $imageUrl = asset('storage/' . $image->path);
                     @endphp
                     <button @click="mainImageUrl = '{{ $imageUrl }}'"
+                            aria-label="Afficher l'image {{ $item->title }}"
                             class="w-24 h-24 rounded-md overflow-hidden border-2 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
                             :class="{ 'border-blue-500': mainImageUrl === '{{ $imageUrl }}', 'border-transparent': mainImageUrl !== '{{ $imageUrl }}' }">
                         <img src="{{ $imageUrl }}"


### PR DESCRIPTION
**What**: Added an `aria-label` attribute to the `<button>` element used for gallery image thumbnails.
**Why**: Icon-only or image-only interactive elements need an explicit accessible name to be correctly interpreted by assistive technologies.
**Before/After screenshots**: N/A (this is an invisible accessibility change for screen readers).
**Accessibility**: Clarified the interaction purpose for screen reader users by providing a descriptive label ("Afficher l'image [titre]").

---
*PR created automatically by Jules for task [9202998092456644364](https://jules.google.com/task/9202998092456644364) started by @Ganngann*