### PR TITLE
⚡ Bolt: Pre-calculate image count during upload to prevent N+1 query

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -2,3 +2,7 @@
 **Learning:** Checking `Auth::user()->unreadNotifications->count()` inside the navigation layout triggers an N+1 query issue since notifications might not be loaded, and `count()` triggers a separate count query on the relation each time it's called (or loads all notifications). Actually, it loads the relation because it uses the property `unreadNotifications` and then calls `count()` on the collection. In this case, `unreadNotifications()->count()` is much more efficient as it performs an aggregate query, but even better is doing it right in a View Composer if needed, or just `unreadNotifications()->count()`. Wait, since it's `Auth::user()->unreadNotifications->count()`, it loads ALL unread notifications into memory just to count them!
 
 **Action:** Replace `$user->unreadNotifications->count()` with `$user->unreadNotifications()->count()`. This executes a simple `COUNT(*)` query without fetching the actual model records.
+
+## 2026-07-14 - [N+1 query in loop]
+**Learning:** Checking `$item->images()->count()` inside a foreach loop that uploads images runs a SELECT COUNT(*) query on every iteration. Since the count is known before the loop (current images count + uploaded images count), we can calculate the limit before the loop, avoiding N queries where N is the number of uploaded images.
+**Action:** Calculate the remaining image slots before the loop and use an iteration counter instead of querying the database on every loop iteration.

--- a/pifpaf/app/Http/Controllers/ItemController.php
+++ b/pifpaf/app/Http/Controllers/ItemController.php
@@ -406,9 +406,12 @@ class ItemController extends Controller
             // On récupère le dernier ordre pour continuer la séquence
             $order = $item->images()->max('order') + 1;
 
+            // Optimization: Pre-calculate the current image count to prevent an N+1 query issue inside the foreach loop
+            $currentImageCount = $item->images()->count();
+
             foreach ($request->file('images') as $imageFile) {
                 // On vérifie qu'on ne dépasse pas la limite totale de 10 images
-                if ($item->images()->count() >= 10) {
+                if ($currentImageCount >= 10) {
                     break;
                 }
 
@@ -417,6 +420,7 @@ class ItemController extends Controller
                     'path' => $path,
                     'order' => $order++,
                 ]);
+                $currentImageCount++;
             }
         }
 


### PR DESCRIPTION
💡 What: Extracted the `$item->images()->count()` calculation out of the `foreach` loop that processes uploaded images. The count is now pre-calculated before the loop, and an iteration counter is used instead.

🎯 Why: During image uploads, calling `$item->images()->count()` inside the loop runs a `SELECT COUNT(*)` query against the database for every single image being processed, leading to an N+1 query bottleneck. Pre-calculating it eliminates these unnecessary queries.

📊 Impact: Reduces database queries from N (where N is the number of uploaded images) to just 1 query per image upload batch.

🔬 Measurement: Check the database query logs during an item update with multiple image uploads; the `SELECT COUNT(*)` query will only run once instead of N times.

---
*PR created automatically by Jules for task [12793431477270800146](https://jules.google.com/task/12793431477270800146) started by @Ganngann*