### PR TITLE
🎨 Palette: Ajouter un aria-label au menu utilisateur

### DIFF
--- a/pifpaf/resources/views/layouts/navigation.blade.php
+++ b/pifpaf/resources/views/layouts/navigation.blade.php
@@ -41,7 +41,7 @@
 
                     <!-- Settings Dropdown -->
                     <div class="relative z-50" x-data="{ open: false }">
-                        <button @click="open = ! open" dusk="nav-user-dropdown" :aria-expanded="open.toString()" class="flex items-center text-sm font-medium text-gray-500 hover:text-gray-700 hover:border-gray-300 focus:outline-none focus:text-gray-700 focus:border-gray-300 transition duration-150 ease-in-out">
+                        <button @click="open = ! open" dusk="nav-user-dropdown" aria-label="Menu utilisateur, {{ Auth::user()->name }}" :aria-expanded="open.toString()" class="flex items-center text-sm font-medium text-gray-500 hover:text-gray-700 hover:border-gray-300 focus:outline-none focus:text-gray-700 focus:border-gray-300 transition duration-150 ease-in-out">
                             <div>{{ Auth::user()->name }}</div>
 
                             <div class="ml-1">


### PR DESCRIPTION
💡 **What:** Added an `aria-label` to the user profile dropdown button in the navigation bar.
🎯 **Why:** To improve accessibility. Without an explicit label, a screen reader would likely just read the user's name, which doesn't indicate that the element is an interactive menu dropdown.
📸 **Before/After:** Not applicable (invisible DOM change).
♿ **Accessibility:** This directly improves screen reader accessibility by providing context that the element is a "Menu utilisateur" and associating it with the user's name. It adheres to WCAG 2.5.3 by ensuring the visible text (the user's name) is included within the aria-label.

---
*PR created automatically by Jules for task [15834639162634935929](https://jules.google.com/task/15834639162634935929) started by @Ganngann*