### PR TITLE
🎨 Palette: Form accessibility and focus improvements

### DIFF
--- a/pifpaf/.Jules/palette.md
+++ b/pifpaf/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-07-16 - Form Accessibility & Focus States
+**Learning:** The welcome page search form grouped inputs (like min/max price and location/distance) under a single visual label without explicitly associating them with `id` or `aria-label`. Additionally, these inputs were missing clear focus rings for keyboard navigation.
+**Action:** When working on complex forms with grouped inputs in this project, explicitly add `aria-label` attributes to individual inputs when standard `<label for="...">` isn't practical, and ensure all interactive elements include explicit focus states (e.g. `focus:ring-2 focus:ring-blue-500 focus:outline-none`).

--- a/pifpaf/resources/views/welcome.blade.php
+++ b/pifpaf/resources/views/welcome.blade.php
@@ -9,13 +9,13 @@
                     <!-- Champ de recherche par mot-clé -->
                     <div class="flex-grow min-w-[200px] md:flex-grow-[2]">
                         <label for="search" class="block text-sm font-medium text-gray-700 mb-1">Recherche</label>
-                        <input type="text" id="search" name="search" placeholder="Que recherchez-vous ?" class="w-full px-4 py-2 border rounded-lg" value="{{ request('search') }}">
+                        <input type="text" id="search" name="search" placeholder="Que recherchez-vous ?" class="w-full px-4 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none" value="{{ request('search') }}">
                     </div>
 
                     <!-- Filtre par catégorie -->
                     <div class="flex-grow min-w-[150px]">
                         <label for="category" class="block text-sm font-medium text-gray-700 mb-1">Catégorie</label>
-                        <select id="category" name="category" class="w-full px-4 py-2 border rounded-lg">
+                        <select id="category" name="category" class="w-full px-4 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none">
                             <option value="">Toutes</option>
                             <option value="Vêtements" @if(request('category') == 'Vêtements') selected @endif>Vêtements</option>
                             <option value="Électronique" @if(request('category') == 'Électronique') selected @endif>Électronique</option>
@@ -30,9 +30,9 @@
                     <div class="flex-grow min-w-[180px]">
                         <label class="block text-sm font-medium text-gray-700 mb-1">Prix</label>
                         <div class="flex items-center gap-2">
-                            <input type="number" name="min_price" placeholder="Min" class="w-full px-2 py-2 border rounded-lg" value="{{ request('min_price') }}">
+                            <input type="number" name="min_price" aria-label="Prix minimum" placeholder="Min" class="w-full px-2 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none" value="{{ request('min_price') }}">
                             <span>-</span>
-                            <input type="number" name="max_price" placeholder="Max" class="w-full px-2 py-2 border rounded-lg" value="{{ request('max_price') }}">
+                            <input type="number" name="max_price" aria-label="Prix maximum" placeholder="Max" class="w-full px-2 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none" value="{{ request('max_price') }}">
                         </div>
                     </div>
 
@@ -40,8 +40,8 @@
                     <div class="flex-grow min-w-[180px]">
                          <label class="block text-sm font-medium text-gray-700 mb-1">Localisation</label>
                          <div class="flex items-center gap-2">
-                            <input type="text" name="location" placeholder="Autour de..." class="w-full px-4 py-2 border rounded-lg" value="{{ request('location') }}">
-                            <select name="distance" class="w-full px-4 py-2 border rounded-lg">
+                            <input type="text" name="location" aria-label="Ville de recherche" placeholder="Autour de..." class="w-full px-4 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none" value="{{ request('location') }}">
+                            <select name="distance" aria-label="Distance autour de la ville" class="w-full px-4 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none">
                                 <option value="">Dist.</option>
                                 <option value="10" @if(request('distance') == '10') selected @endif>10 km</option>
                                 <option value="25" @if(request('distance') == '25') selected @endif>25 km</option>


### PR DESCRIPTION
💡 **What**: Added explicit focus states (`focus:ring-2 focus:ring-blue-500 ...`) to all interactive elements on the search form of the welcome page. Also added `aria-label` attributes to grouped inputs (like Min/Max price and Location/Distance) that shared a single visual label without `id`/`for` mapping.

🎯 **Why**: To ensure users navigating via keyboard can easily see which element is focused, and to ensure users navigating via screen readers have proper context for grouped inputs.

📸 **Before/After**: N/A (Visual change only affects focus state ring).

♿ **Accessibility**: 
- Improves WCAG 2.1 Success Criterion 2.4.7 (Focus Visible) by adding clear focus rings to inputs.
- Improves WCAG 2.1 Success Criterion 4.1.2 (Name, Role, Value) by ensuring grouped inputs have accessible names via `aria-label` where standard `label for` mapping wasn't used.

---
*PR created automatically by Jules for task [1896087563626011729](https://jules.google.com/task/1896087563626011729) started by @Ganngann*