### PR TITLE
🎨 Palette: Improve keyboard accessibility on search form

### DIFF
--- a/pifpaf/resources/views/welcome.blade.php
+++ b/pifpaf/resources/views/welcome.blade.php
@@ -9,13 +9,13 @@
                     <!-- Champ de recherche par mot-clé -->
                     <div class="flex-grow min-w-[200px] md:flex-grow-[2]">
                         <label for="search" class="block text-sm font-medium text-gray-700 mb-1">Recherche</label>
-                        <input type="text" id="search" name="search" placeholder="Que recherchez-vous ?" class="w-full px-4 py-2 border rounded-lg" value="{{ request('search') }}">
+                        <input type="text" id="search" name="search" placeholder="Que recherchez-vous ?" class="w-full px-4 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none" value="{{ request('search') }}">
                     </div>
 
                     <!-- Filtre par catégorie -->
                     <div class="flex-grow min-w-[150px]">
                         <label for="category" class="block text-sm font-medium text-gray-700 mb-1">Catégorie</label>
-                        <select id="category" name="category" class="w-full px-4 py-2 border rounded-lg">
+                        <select id="category" name="category" class="w-full px-4 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none">
                             <option value="">Toutes</option>
                             <option value="Vêtements" @if(request('category') == 'Vêtements') selected @endif>Vêtements</option>
                             <option value="Électronique" @if(request('category') == 'Électronique') selected @endif>Électronique</option>
@@ -28,20 +28,20 @@
 
                     <!-- Filtres de prix -->
                     <div class="flex-grow min-w-[180px]">
-                        <label class="block text-sm font-medium text-gray-700 mb-1">Prix</label>
-                        <div class="flex items-center gap-2">
-                            <input type="number" name="min_price" placeholder="Min" class="w-full px-2 py-2 border rounded-lg" value="{{ request('min_price') }}">
-                            <span>-</span>
-                            <input type="number" name="max_price" placeholder="Max" class="w-full px-2 py-2 border rounded-lg" value="{{ request('max_price') }}">
+                        <label class="block text-sm font-medium text-gray-700 mb-1" id="price-group-label">Prix</label>
+                        <div class="flex items-center gap-2" role="group" aria-labelledby="price-group-label">
+                            <input type="number" name="min_price" aria-label="Prix minimum" placeholder="Min" class="w-full px-2 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none" value="{{ request('min_price') }}">
+                            <span aria-hidden="true">-</span>
+                            <input type="number" name="max_price" aria-label="Prix maximum" placeholder="Max" class="w-full px-2 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none" value="{{ request('max_price') }}">
                         </div>
                     </div>
 
                     <!-- Filtres de distance -->
                     <div class="flex-grow min-w-[180px]">
-                         <label class="block text-sm font-medium text-gray-700 mb-1">Localisation</label>
-                         <div class="flex items-center gap-2">
-                            <input type="text" name="location" placeholder="Autour de..." class="w-full px-4 py-2 border rounded-lg" value="{{ request('location') }}">
-                            <select name="distance" class="w-full px-4 py-2 border rounded-lg">
+                         <label class="block text-sm font-medium text-gray-700 mb-1" id="location-group-label">Localisation</label>
+                         <div class="flex items-center gap-2" role="group" aria-labelledby="location-group-label">
+                            <input type="text" name="location" aria-label="Localisation" placeholder="Autour de..." class="w-full px-4 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none" value="{{ request('location') }}">
+                            <select name="distance" aria-label="Distance" class="w-full px-4 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none">
                                 <option value="">Dist.</option>
                                 <option value="10" @if(request('distance') == '10') selected @endif>10 km</option>
                                 <option value="25" @if(request('distance') == '25') selected @endif>25 km</option>
@@ -53,7 +53,7 @@
 
                     <!-- Bouton de soumission -->
                     <div class="flex-shrink-0">
-                        <button type="submit" class="w-full bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-lg">
+                        <button type="submit" class="w-full bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-lg focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:outline-none">
                             Rechercher
                         </button>
                     </div>


### PR DESCRIPTION
💡 **What**: Added explicit Tailwind CSS focus states (`focus:ring-2`, `focus:outline-none`, etc.) to all form inputs, selects, and the submit button in the welcome page search form. Grouped related inputs and added descriptive `aria-label`s.
🎯 **Why**: To make the search form fully accessible via keyboard navigation and screen readers, ensuring a smoother experience for all users.
📸 **Before/After**: N/A (visual change only visible on interaction/focus).
♿ **Accessibility**: 
- Added `aria-label` to inputs inside grouped structures ("Prix minimum", "Prix maximum", "Localisation", "Distance").
- Grouped related fields using `role="group"` and `aria-labelledby`.
- Added clear focus indicators for keyboard navigation.
- Hid decorative elements (like dashes) from screen readers using `aria-hidden="true"`.

---
*PR created automatically by Jules for task [14209219680900371173](https://jules.google.com/task/14209219680900371173) started by @Ganngann*