### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix IDOR in bulk image reordering

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,7 @@
 **Vulnerability:** The application had a critical path traversal vulnerability in `AiRequestController.php` and `ItemController.php` where user-controlled input (`image_path`, `original_image_path`) was passed directly to `Storage::disk('public')->path()` and `Storage::disk('public')->move()` without proper sanitization. This allowed attackers to potentially read or move arbitrary files on the server using `../../` sequences.
 **Learning:** Even when using Laravel's storage facade, unsanitized user input passed to methods like `path()`, `exists()`, or `move()` is unsafe. Path parameters received from external requests must be strictly validated.
 **Prevention:** Always validate file paths from external input using strict regex constraints (e.g., `regex:/^ai_images\/[a-zA-Z0-9_\-\.]+$/`) to ensure they only point to expected directories and do not contain directory traversal sequences.
+## 2026-07-17 - IDOR in Bulk Updates
+**Vulnerability:** Bulk update operations (like reordering item images) that receive an array of IDs but only authorize the parent model based on the first ID.
+**Learning:** A malicious user could pass an array where the first ID belongs to their own item (passing authorization), and subsequent IDs belong to other users' items, allowing unauthorized modification.
+**Prevention:** When processing an array of IDs for a bulk update, ensure *all* submitted IDs belong to the authorized parent model before executing the update loop (e.g., using a whereIn count assertion against the relationship).

--- a/pifpaf/app/Http/Controllers/ItemImageController.php
+++ b/pifpaf/app/Http/Controllers/ItemImageController.php
@@ -3,9 +3,10 @@
 namespace App\Http\Controllers;
 
 use App\Models\ItemImage;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
-use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 
 class ItemImageController extends Controller
 {
@@ -14,8 +15,7 @@ class ItemImageController extends Controller
     /**
      * Supprime une image d'annonce.
      *
-     * @param  \App\Models\ItemImage  $itemImage
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function destroy(ItemImage $itemImage)
     {
@@ -37,8 +37,7 @@ class ItemImageController extends Controller
     /**
      * Définit une image comme principale.
      *
-     * @param  \App\Models\ItemImage  $itemImage
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function setPrimary(ItemImage $itemImage)
     {
@@ -59,18 +58,24 @@ class ItemImageController extends Controller
     /**
      * Réorganise l'ordre des images.
      *
-     * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function reorder(Request $request)
     {
         $request->validate([
-            'ids' => 'required|array',
+            'ids' => 'required|array|min:1',
             'ids.*' => 'exists:item_images,id',
         ]);
 
         $itemImage = ItemImage::find($request->ids[0]);
-        $this->authorize('update', $itemImage->item);
+        $item = $itemImage->item;
+        $this->authorize('update', $item);
+
+        // Security: Ensure all submitted image IDs belong to the authorized item
+        $validImageCount = $item->images()->whereIn('id', $request->ids)->count();
+        if ($validImageCount !== count($request->ids)) {
+            abort(403, 'Unauthorized attempt to modify images belonging to another item.');
+        }
 
         foreach ($request->ids as $index => $id) {
             ItemImage::where('id', $id)->update(['order' => $index]);


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `ItemImageController@reorder` method received an array of image IDs but only authorized the parent `Item` model based on the first ID. A malicious user could submit an array where the first ID belonged to their item, passing the authorization check, while subsequent IDs belonged to other users' items, allowing unauthorized modification of their order.
🎯 Impact: Attackers could arbitrarily reorder images of items belonging to other users.
🔧 Fix: Updated the `reorder` method to retrieve the authorized parent `Item` based on the first ID, and then added a query to count the number of images matching the submitted IDs that actually belong to that specific `Item`. If the count does not match the size of the submitted array, the request is aborted with a 403 status. Also updated validation to require at least one ID in the array.
✅ Verification: Ran `php artisan test` locally and confirmed `ItemImageControllerTest` passes, demonstrating users cannot modify other users' images.

---
*PR created automatically by Jules for task [8802663695587908207](https://jules.google.com/task/8802663695587908207) started by @Ganngann*