### PR TITLE
🎨 Palette: Add explicit focus rings to form inputs for Tailwind v4 compatibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-05-16 - Add ARIA Labels to Navigation Elements
 **Learning:** Icon-only links and toggle buttons (like the notifications bell and hamburger menu) are common in Laravel Breeze/Alpine navigation components but often lack accessible labels by default.
 **Action:** When adding or reviewing icon-only interactive elements, ensure `aria-label` is present. For elements that toggle state (like dropdowns or mobile menus), bind `aria-expanded` to the state variable (e.g., `:aria-expanded="open.toString()"` in Alpine.js) to communicate state to screen readers.
+
+## 2026-07-18 - Tailwind CSS v4 Focus States
+**Learning:** Tailwind CSS v4 removes the `focus:shadow-outline` class. To maintain keyboard accessibility on interactive form elements like inputs and selects, you must explicitly define focus states.
+**Action:** Use `focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none` (or similar explicit ring/border classes) instead of the deprecated `focus:shadow-outline` class.

--- a/pifpaf/resources/views/components/item-form.blade.php
+++ b/pifpaf/resources/views/components/item-form.blade.php
@@ -18,19 +18,19 @@
     <!-- Titre -->
     <div class="mb-4">
         <label for="title" class="block text-gray-700 text-sm font-bold mb-2">Titre</label>
-        <input type="text" name="title" id="title" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" value="{{ old('title', $item->title ?? session('ai_data')['title'] ?? '') }}" required>
+        <input type="text" name="title" id="title" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none" value="{{ old('title', $item->title ?? session('ai_data')['title'] ?? '') }}" required>
     </div>
 
     <!-- Description -->
     <div class="mb-4">
         <label for="description" class="block text-gray-700 text-sm font-bold mb-2">Description</label>
-        <textarea name="description" id="description" rows="4" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" required>{{ old('description', $item->description ?? session('ai_data')['description'] ?? '') }}</textarea>
+        <textarea name="description" id="description" rows="4" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none" required>{{ old('description', $item->description ?? session('ai_data')['description'] ?? '') }}</textarea>
     </div>
 
     <!-- Catégorie -->
     <div class="mb-4">
         <label for="category" class="block text-gray-700 text-sm font-bold mb-2">Catégorie</label>
-        <select name="category" id="category" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" required>
+        <select name="category" id="category" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none" required>
             <option value="">-- Choisir une catégorie --</option>
             @php
                 $selectedCategory = old('category', $item->category ?? session('ai_data')['category'] ?? '');
@@ -45,26 +45,26 @@
     <!-- Prix -->
     <div class="mb-4">
         <label for="price" class="block text-gray-700 text-sm font-bold mb-2">Prix</label>
-        <input type="number" step="0.01" name="price" id="price" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" value="{{ old('price', $item->price ?? session('ai_data')['price'] ?? '') }}" required>
+        <input type="number" step="0.01" name="price" id="price" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none" value="{{ old('price', $item->price ?? session('ai_data')['price'] ?? '') }}" required>
     </div>
 
     <!-- Poids et Dimensions -->
     <div class="grid grid-cols-1 md:grid-cols-4 gap-4 mb-4">
         <div>
             <label for="weight" class="block text-gray-700 text-sm font-bold mb-2">Poids (g)</label>
-            <input type="number" name="weight" id="weight" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" value="{{ old('weight', $item->weight ?? session('ai_data')['weight'] ?? '') }}">
+            <input type="number" name="weight" id="weight" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none" value="{{ old('weight', $item->weight ?? session('ai_data')['weight'] ?? '') }}">
         </div>
         <div>
             <label for="width" class="block text-gray-700 text-sm font-bold mb-2">Largeur (cm)</label>
-            <input type="number" name="width" id="width" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" value="{{ old('width', $item->width ?? session('ai_data')['width'] ?? '') }}">
+            <input type="number" name="width" id="width" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none" value="{{ old('width', $item->width ?? session('ai_data')['width'] ?? '') }}">
         </div>
         <div>
             <label for="height" class="block text-gray-700 text-sm font-bold mb-2">Hauteur (cm)</label>
-            <input type="number" name="height" id="height" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" value="{{ old('height', $item->height ?? session('ai_data')['height'] ?? '') }}">
+            <input type="number" name="height" id="height" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none" value="{{ old('height', $item->height ?? session('ai_data')['height'] ?? '') }}">
         </div>
         <div>
             <label for="length" class="block text-gray-700 text-sm font-bold mb-2">Longeur (cm)</label>
-            <input type="number" name="length" id="length" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" value="{{ old('length', $item->length ?? session('ai_data')['length'] ?? '') }}">
+            <input type="number" name="length" id="length" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none" value="{{ old('length', $item->length ?? session('ai_data')['length'] ?? '') }}">
         </div>
     </div>
 
@@ -92,7 +92,7 @@
         <!-- Sélection de l'adresse de retrait (conditionnelle) -->
         <div x-show="pickupAvailable" class="mb-4">
             <label for="address_id" class="block text-gray-700 text-sm font-bold mb-2">Adresse de retrait</label>
-            <select name="address_id" id="address_id" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline">
+            <select name="address_id" id="address_id" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none">
                 <option value="">-- Choisir une adresse --</option>
                 @foreach($pickupAddresses as $address)
                     <option value="{{ $address->id }}" @if(old('address_id', $item->address_id ?? null) == $address->id) selected @endif>
@@ -106,7 +106,7 @@
 
     <!-- Bouton de soumission -->
     <div class="flex items-center justify-end mt-4">
-        <button type="submit" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline">
+        <button type="submit" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none">
             {{ $submitText }}
         </button>
     </div>


### PR DESCRIPTION
💡 What: Replaced the deprecated Tailwind CSS v4 `focus:shadow-outline` class with explicit focus ring classes (`focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none`) on all form inputs and selects within `resources/views/components/item-form.blade.php`.
🎯 Why: Tailwind CSS v4 removes the `focus:shadow-outline` utility. Without an explicit replacement, interactive form elements lose their visual focus indicators, severely impacting keyboard navigation and violating accessibility standards. This change restores the expected visual feedback.
📸 Before/After: Inputs previously showed no focus ring when clicked or tabbed into. Now, a clear blue ring appears on focus.
♿ Accessibility: Ensures that keyboard users and screen reader users navigating via the `Tab` key receive clear visual confirmation of the currently active form field, complying with WCAG 2.4.7 Focus Visible.

---
*PR created automatically by Jules for task [12918849024624802555](https://jules.google.com/task/12918849024624802555) started by @Ganngann*