### PR TITLE
🛡️ Sentinel: [HIGH] Fix IDOR in foreign key assignment and bulk updates

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,7 @@
 **Vulnerability:** The application had a critical path traversal vulnerability in `AiRequestController.php` and `ItemController.php` where user-controlled input (`image_path`, `original_image_path`) was passed directly to `Storage::disk('public')->path()` and `Storage::disk('public')->move()` without proper sanitization. This allowed attackers to potentially read or move arbitrary files on the server using `../../` sequences.
 **Learning:** Even when using Laravel's storage facade, unsanitized user input passed to methods like `path()`, `exists()`, or `move()` is unsafe. Path parameters received from external requests must be strictly validated.
 **Prevention:** Always validate file paths from external input using strict regex constraints (e.g., `regex:/^ai_images\/[a-zA-Z0-9_\-\.]+$/`) to ensure they only point to expected directories and do not contain directory traversal sequences.
+## 2026-07-19 - Prevent IDOR in Bulk Updates and Foreign Keys
+**Vulnerability:** IDOR vulnerabilities found in foreign key assignments (address_id) and bulk updates (image reordering).
+**Learning:** Relying only on `exists:table,id` or checking only the first item in an array leaves endpoints vulnerable to IDOR.
+**Prevention:** Always scope validation queries for foreign keys to the authenticated user using `Rule::exists(...)->where(...)`. For bulk operations on child records, ensure all submitted IDs belong to the authorized parent model.

--- a/pifpaf/app/Http/Controllers/ItemController.php
+++ b/pifpaf/app/Http/Controllers/ItemController.php
@@ -8,6 +8,7 @@ use App\Models\AiRequest;
 use App\Models\Item;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
 use App\Services\GoogleAiService;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Http;
@@ -306,7 +307,14 @@ class ItemController extends Controller
             'image_path' => ['sometimes', 'string', 'regex:/^ai_images\/[a-zA-Z0-9_\-\.]+$/'],
             'delivery_available' => 'sometimes|boolean',
             'pickup_available' => 'sometimes|boolean',
-            'address_id' => 'required_if:pickup_available,true|nullable|exists:addresses,id',
+            // Security: Prevent IDOR by ensuring the provided address belongs to the authenticated user.
+            'address_id' => [
+                'required_if:pickup_available,true',
+                'nullable',
+                Rule::exists('addresses', 'id')->where(function ($query) {
+                    $query->where('user_id', Auth::id());
+                }),
+            ],
             'weight' => 'required_if:delivery_available,true|nullable|numeric|min:1',
             'length' => 'required_if:delivery_available,true|nullable|numeric|min:1',
             'width' => 'required_if:delivery_available,true|nullable|numeric|min:1',
@@ -387,7 +395,14 @@ class ItemController extends Controller
             'images.*' => 'image|mimes:jpeg,png,jpg|max:2048',
             'delivery_available' => 'sometimes|boolean',
             'pickup_available' => 'sometimes|boolean',
-            'address_id' => 'required_if:pickup_available,true|nullable|exists:addresses,id',
+            // Security: Prevent IDOR by ensuring the provided address belongs to the authenticated user.
+            'address_id' => [
+                'required_if:pickup_available,true',
+                'nullable',
+                Rule::exists('addresses', 'id')->where(function ($query) {
+                    $query->where('user_id', Auth::id());
+                }),
+            ],
             'weight' => 'required_if:delivery_available,true|nullable|numeric|min:1',
             'length' => 'required_if:delivery_available,true|nullable|numeric|min:1',
             'width' => 'required_if:delivery_available,true|nullable|numeric|min:1',

--- a/pifpaf/app/Http/Controllers/ItemImageController.php
+++ b/pifpaf/app/Http/Controllers/ItemImageController.php
@@ -72,6 +72,13 @@ class ItemImageController extends Controller
         $itemImage = ItemImage::find($request->ids[0]);
         $this->authorize('update', $itemImage->item);
 
+        // Security: Prevent IDOR by ensuring all submitted image IDs belong to the authorized item
+        $item = $itemImage->item;
+        $count = $item->images()->whereIn('id', $request->ids)->count();
+        if ($count !== count($request->ids)) {
+            abort(403, 'Accès non autorisé aux images spécifiées.');
+        }
+
         foreach ($request->ids as $index => $id) {
             ItemImage::where('id', $id)->update(['order' => $index]);
         }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Insecure Direct Object Reference (IDOR) in foreign key assignments (`address_id` during item creation/update) and bulk operations (image reordering).
🎯 **Impact:** An attacker could assign another user's address to their items or reorder images belonging to items they do not own.
🔧 **Fix:** 
- In `ItemController.php`, updated the validation rule for `address_id` to use `Rule::exists('addresses', 'id')->where(function ($query) { $query->where('user_id', Auth::id()); })`, ensuring the address belongs to the authenticated user.
- In `ItemImageController.php`, added a check in `reorder` to verify that the count of images matching the submitted IDs and belonging to the authorized item equals the total number of submitted IDs.
✅ **Verification:** 
- Simulated requests using Tinker confirm that attempting to use a victim's `address_id` now fails validation.
- Simulated requests confirm that including a victim's image ID in the `reorder` payload now results in a 403 error.
- Full test suite passes without regressions.

---
*PR created automatically by Jules for task [12302718660212607195](https://jules.google.com/task/12302718660212607195) started by @Ganngann*