### PR TITLE
🛡️ Sentinel: [HIGH] Fix IDOR in item image reordering

### DIFF
--- a/pifpaf/.jules/sentinel.md
+++ b/pifpaf/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2026-07-23 - Insecure Direct Object Reference in Bulk Reorder
+**Vulnerability:** IDOR in the ItemImageController@reorder method. When users passed an array of image IDs, the controller only validated authorization against the first ID. A malicious user could pass their own image ID as the first element, and another user's image ID in subsequent elements, allowing them to modify the order of images they didn't own.
+**Learning:** When performing bulk updates based on an array of IDs, it is insufficient to check authorization against just one ID. The authorization check must ensure all submitted IDs belong to the authorized parent model.
+**Prevention:** When mitigating IDOR for bulk updates, authorize the parent model and ensure *all* submitted IDs belong to it by querying the relationship (e.g., `$model->children()->whereIn('id', $ids)->count()`) and asserting the retrieved count exactly matches the input array length. Alternatively, scope the update query to the authorized model's relationship instead of updating the child model directly.

--- a/pifpaf/app/Http/Controllers/ItemImageController.php
+++ b/pifpaf/app/Http/Controllers/ItemImageController.php
@@ -3,9 +3,10 @@
 namespace App\Http\Controllers;
 
 use App\Models\ItemImage;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
-use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 
 class ItemImageController extends Controller
 {
@@ -14,8 +15,7 @@ class ItemImageController extends Controller
     /**
      * Supprime une image d'annonce.
      *
-     * @param  \App\Models\ItemImage  $itemImage
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function destroy(ItemImage $itemImage)
     {
@@ -37,8 +37,7 @@ class ItemImageController extends Controller
     /**
      * Définit une image comme principale.
      *
-     * @param  \App\Models\ItemImage  $itemImage
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function setPrimary(ItemImage $itemImage)
     {
@@ -59,8 +58,7 @@ class ItemImageController extends Controller
     /**
      * Réorganise l'ordre des images.
      *
-     * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function reorder(Request $request)
     {
@@ -69,11 +67,16 @@ class ItemImageController extends Controller
             'ids.*' => 'exists:item_images,id',
         ]);
 
-        $itemImage = ItemImage::find($request->ids[0]);
-        $this->authorize('update', $itemImage->item);
+        $itemImage = ItemImage::findOrFail($request->ids[0]);
+        $item = $itemImage->item;
+        $this->authorize('update', $item);
+
+        if ($item->images()->whereIn('id', $request->ids)->count() !== count($request->ids)) {
+            abort(403, 'Unauthorized action.');
+        }
 
         foreach ($request->ids as $index => $id) {
-            ItemImage::where('id', $id)->update(['order' => $index]);
+            $item->images()->where('id', $id)->update(['order' => $index]);
         }
 
         return response()->json(['success' => true]);

--- a/pifpaf/tests/Feature/ItemImageControllerTest.php
+++ b/pifpaf/tests/Feature/ItemImageControllerTest.php
@@ -128,4 +128,39 @@ class ItemImageControllerTest extends TestCase
         ]);
         $responseReorder->assertForbidden();
     }
+
+    public function test_user_cannot_reorder_other_users_images_in_bulk(): void
+    {
+        $user = User::factory()->create();
+        $otherUser = User::factory()->create();
+
+        $item = Item::factory()->create(['user_id' => $user->id]);
+        $otherItem = Item::factory()->create(['user_id' => $otherUser->id]);
+
+        $image1 = ItemImage::create([
+            'item_id' => $item->id,
+            'path' => 'fake1.jpg',
+            'is_primary' => false,
+            'order' => 0,
+        ]);
+
+        $image2 = ItemImage::create([
+            'item_id' => $otherItem->id,
+            'path' => 'fake2.jpg',
+            'is_primary' => false,
+            'order' => 1,
+        ]);
+
+        $response = $this->actingAs($user)->postJson(route('item-images.reorder'), [
+            'ids' => [$image1->id, $image2->id],
+        ]);
+
+        $response->assertForbidden();
+
+        // Assert victim's image was not modified
+        $this->assertDatabaseHas('item_images', [
+            'id' => $image2->id,
+            'order' => 1,
+        ]);
+    }
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: IDOR in bulk item image reordering, the server only checked the first image ID in the array.
🎯 Impact: Users could modify the order of other users' images.
🔧 Fix: Validate that all requested image IDs belong to the authorized item before updating, and scope updates to the item.
✅ Verification: Run `php artisan test` and check `ItemImageControllerTest`.

---
*PR created automatically by Jules for task [17598614849777149322](https://jules.google.com/task/17598614849777149322) started by @Ganngann*