### PR TITLE
🛡️ Sentinel: [HIGH] Fix IDOR in ItemImage reorder

### DIFF
--- a/pifpaf/.jules/sentinel.md
+++ b/pifpaf/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-07-24 - Insecure Direct Object Reference in Bulk Action
+**Vulnerability:** IDOR in the ItemImageController's bulk reorder method allowed attackers to modify the order of images belonging to other users' items by including their own authorized image ID as the first element in the request payload.
+**Learning:** Checking authorization only against the first element of an array of user-submitted IDs is insufficient for bulk operations. The authorization boundary must cover the entire dataset being operated on.
+**Prevention:** For any action processing an array of IDs, ensure that every single ID in the array belongs to the authorized resource model by performing a scoped `whereIn` count check before executing the operation.

--- a/pifpaf/app/Http/Controllers/ItemImageController.php
+++ b/pifpaf/app/Http/Controllers/ItemImageController.php
@@ -3,9 +3,10 @@
 namespace App\Http\Controllers;
 
 use App\Models\ItemImage;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
-use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 
 class ItemImageController extends Controller
 {
@@ -14,8 +15,7 @@ class ItemImageController extends Controller
     /**
      * Supprime une image d'annonce.
      *
-     * @param  \App\Models\ItemImage  $itemImage
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function destroy(ItemImage $itemImage)
     {
@@ -37,8 +37,7 @@ class ItemImageController extends Controller
     /**
      * Définit une image comme principale.
      *
-     * @param  \App\Models\ItemImage  $itemImage
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function setPrimary(ItemImage $itemImage)
     {
@@ -59,8 +58,7 @@ class ItemImageController extends Controller
     /**
      * Réorganise l'ordre des images.
      *
-     * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function reorder(Request $request)
     {
@@ -71,6 +69,15 @@ class ItemImageController extends Controller
 
         $itemImage = ItemImage::find($request->ids[0]);
         $this->authorize('update', $itemImage->item);
+
+        // Security check for IDOR: ensure all provided image IDs actually belong
+        // to the item we just authorized against. This prevents an attacker from
+        // including their own image as the first ID (to pass authorization) and
+        // then modifying the order of images belonging to other users.
+        $validImagesCount = $itemImage->item->images()->whereIn('id', $request->ids)->count();
+        if ($validImagesCount !== count($request->ids)) {
+            abort(403, 'Unauthorized action.');
+        }
 
         foreach ($request->ids as $index => $id) {
             ItemImage::where('id', $id)->update(['order' => $index]);


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: Insecure Direct Object Reference (IDOR) in `ItemImageController@reorder`. The application accepted an array of image IDs but only checked authorization against the *first* ID in the array. This allowed an attacker to pass one of their own image IDs as `ids[0]` (passing the auth check) and then maliciously reorder other users' images by providing their IDs in the rest of the array.
🎯 **Impact**: An attacker could manipulate the order of images on items they do not own, potentially degrading the listing quality for other users or causing confusion.
🔧 **Fix**: Added a scoped query count check using `$itemImage->item->images()->whereIn('id', $request->ids)->count()`. This ensures that *all* submitted image IDs actually belong to the parent item we just authorized. If the count of matching IDs doesn't equal the total requested IDs, the action is aborted with a 403.
✅ **Verification**: Run `php artisan test` to ensure all tests pass. I also verified the fix with a custom Tinker/test script during exploration.

Included a Sentinel journal entry documenting the importance of boundary checks in bulk operations.
Cleaned up lockfiles to strictly adhere to the <50 line change limit.

---
*PR created automatically by Jules for task [15805695244429108297](https://jules.google.com/task/15805695244429108297) started by @Ganngann*