### PR TITLE
🛡️ Sentinel: [HIGH] Fix IDOR in DisputeController

### DIFF
--- a/pifpaf/.jules/sentinel.md
+++ b/pifpaf/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-07-25 - Insecure Direct Object Reference (IDOR) in Dispute Creation
+**Vulnerability:** The `DisputeController`'s `create` and `store` methods lacked authorization checks, allowing any authenticated user to open a dispute for any transaction by explicitly calling the endpoint with a valid transaction ID.
+**Learning:** Controllers that handle business actions (like creating disputes for transactions) but do not extend a base controller with `AuthorizesRequests` can easily miss crucial permission checks if relying solely on UI hidden buttons.
+**Prevention:** Always enforce authorization at the controller level using `abort_unless()` or by explicitly importing the `AuthorizesRequests` trait and using `$this->authorize()` to verify model ownership or relationship permissions on every protected endpoint.

--- a/pifpaf/app/Http/Controllers/DisputeController.php
+++ b/pifpaf/app/Http/Controllers/DisputeController.php
@@ -10,11 +10,17 @@ class DisputeController extends Controller
 {
     public function create(Transaction $transaction)
     {
+        // Prevent IDOR: Ensure only the buyer can create a dispute
+        abort_unless($transaction->offer->user_id === auth()->id(), 403, 'Unauthorized action.');
+
         return view('disputes.create', compact('transaction'));
     }
 
     public function store(Request $request, Transaction $transaction)
     {
+        // Prevent IDOR: Ensure only the buyer can store a dispute
+        abort_unless($transaction->offer->user_id === auth()->id(), 403, 'Unauthorized action.');
+
         $request->validate([
             'reason' => 'required|string|min:20',
         ]);

--- a/pifpaf/tests/Feature/DisputeCreationTest.php
+++ b/pifpaf/tests/Feature/DisputeCreationTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Feature;
 
 use App\Enums\TransactionStatus;
-use App\Models\Dispute;
 use App\Models\Item;
 use App\Models\Offer;
 use App\Models\Transaction;
@@ -76,5 +75,42 @@ class DisputeCreationTest extends TestCase
             'reason' => 'This is a test reason for the dispute. It is long enough to pass validation.',
         ]);
         $this->assertEquals(TransactionStatus::DISPUTED, $transaction->fresh()->status);
+    }
+
+    public function test_unauthorized_user_cannot_create_a_dispute()
+    {
+        $buyer = User::factory()->create();
+        $seller = User::factory()->create();
+        $unauthorizedUser = User::factory()->create();
+        $item = Item::factory()->create(['user_id' => $seller->id]);
+        $offer = Offer::factory()->create(['item_id' => $item->id, 'user_id' => $buyer->id]);
+        $transaction = Transaction::factory()->create(['offer_id' => $offer->id, 'status' => TransactionStatus::PAYMENT_RECEIVED]);
+
+        $response = $this->actingAs($unauthorizedUser)->post(route('disputes.store', $transaction), [
+            'reason' => 'This is a test reason for the dispute. It is long enough to pass validation.',
+        ]);
+
+        $response->assertStatus(403);
+        $this->assertDatabaseMissing('disputes', [
+            'transaction_id' => $transaction->id,
+        ]);
+    }
+
+    public function test_seller_cannot_create_a_dispute()
+    {
+        $buyer = User::factory()->create();
+        $seller = User::factory()->create();
+        $item = Item::factory()->create(['user_id' => $seller->id]);
+        $offer = Offer::factory()->create(['item_id' => $item->id, 'user_id' => $buyer->id]);
+        $transaction = Transaction::factory()->create(['offer_id' => $offer->id, 'status' => TransactionStatus::PAYMENT_RECEIVED]);
+
+        $response = $this->actingAs($seller)->post(route('disputes.store', $transaction), [
+            'reason' => 'This is a test reason for the dispute. It is long enough to pass validation.',
+        ]);
+
+        $response->assertStatus(403);
+        $this->assertDatabaseMissing('disputes', [
+            'transaction_id' => $transaction->id,
+        ]);
     }
 }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Insecure Direct Object Reference (IDOR) in `DisputeController`. The `create` and `store` endpoints lacked authorization checks, allowing any authenticated user to supply an arbitrary `Transaction` ID and open a dispute for a transaction they were not part of.
🎯 **Impact:** Unauthorized users could manipulate the status of other users' transactions (setting them to `DISPUTED`), potentially causing denial of service or disrupting the dispute resolution process for legitimate buyers and sellers.
🔧 **Fix:** Added `abort_unless($transaction->offer->user_id === auth()->id(), 403, 'Unauthorized action.');` to both methods, explicitly enforcing that only the transaction's buyer can access the dispute creation form and submit a dispute.
✅ **Verification:** 
- Added test `test_unauthorized_user_cannot_create_a_dispute` to verify a 403 response for unrelated users.
- Added test `test_seller_cannot_create_a_dispute` to verify a 403 response for the seller.
- Ran `php artisan test` to confirm all tests pass successfully.

---
*PR created automatically by Jules for task [6040617807955738946](https://jules.google.com/task/6040617807955738946) started by @Ganngann*